### PR TITLE
⚙️[chore] : 엔티티 연관관계 설정 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,3 +35,8 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+//plain-jar 생략
+
+jar{
+	enabled =false
+}

--- a/src/main/java/com/cona/KUsukKusuk/bookmark/domain/Bookmark.java
+++ b/src/main/java/com/cona/KUsukKusuk/bookmark/domain/Bookmark.java
@@ -1,0 +1,26 @@
+package com.cona.KUsukKusuk.bookmark.domain;
+
+import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Bookmark {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "spot_id")
+    private Spot spot;
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/comment/Comment.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/Comment.java
@@ -1,0 +1,29 @@
+package com.cona.KUsukKusuk.comment;
+
+import com.cona.KUsukKusuk.global.domain.BaseEntity;
+import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Comment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "spot_id")
+    private Spot spot;
+
+    private String comment;
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/comment/Comment.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/Comment.java
@@ -3,6 +3,7 @@ package com.cona.KUsukKusuk.comment;
 import com.cona.KUsukKusuk.global.domain.BaseEntity;
 import com.cona.KUsukKusuk.spot.domain.Spot;
 import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -24,6 +25,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "spot_id")
     private Spot spot;
 
+    @Column(nullable = false)
     private String comment;
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/domain/BaseEntity.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/domain/BaseEntity.java
@@ -1,0 +1,23 @@
+package com.cona.KUsukKusuk.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    public LocalDateTime createdDate = LocalDateTime.now().plusHours(9);
+
+    @LastModifiedDate
+    public LocalDateTime updatedDate = LocalDateTime.now().plusHours(9);
+}

--- a/src/main/java/com/cona/KUsukKusuk/like/UserLike.java
+++ b/src/main/java/com/cona/KUsukKusuk/like/UserLike.java
@@ -1,0 +1,26 @@
+package com.cona.KUsukKusuk.like;
+
+import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity(name = "user_like")
+public class UserLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne
+    @JoinColumn(name = "spot_id")
+    private Spot spot;
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/like/UserLike.java
+++ b/src/main/java/com/cona/KUsukKusuk/like/UserLike.java
@@ -3,6 +3,7 @@ package com.cona.KUsukKusuk.like;
 import com.cona.KUsukKusuk.spot.domain.Spot;
 import com.cona.KUsukKusuk.user.domain.User;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -15,11 +16,11 @@ public class UserLike {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id")
     private Spot spot;
 

--- a/src/main/java/com/cona/KUsukKusuk/picture/Picture.java
+++ b/src/main/java/com/cona/KUsukKusuk/picture/Picture.java
@@ -1,0 +1,22 @@
+package com.cona.KUsukKusuk.picture;
+
+import com.cona.KUsukKusuk.spot.domain.Spot;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+
+@Entity
+public class Picture {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "spot_id")
+    private Spot spot;
+    private String pictureUrl;
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/picture/Picture.java
+++ b/src/main/java/com/cona/KUsukKusuk/picture/Picture.java
@@ -1,7 +1,9 @@
 package com.cona.KUsukKusuk.picture;
 
 import com.cona.KUsukKusuk.spot.domain.Spot;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -14,9 +16,10 @@ public class Picture {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "spot_id")
     private Spot spot;
+    @Column(nullable = false)
     private String pictureUrl;
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
@@ -44,5 +44,5 @@ public class Spot extends BaseEntity {
     private String latitude;
     private String review;
 
-    private Long like;
+    private Long likes;
 }

--- a/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
@@ -6,7 +6,9 @@ import com.cona.KUsukKusuk.global.domain.BaseEntity;
 import com.cona.KUsukKusuk.like.UserLike;
 import com.cona.KUsukKusuk.picture.Picture;
 import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -22,7 +24,7 @@ public class Spot extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
@@ -37,11 +39,13 @@ public class Spot extends BaseEntity {
 
     @OneToMany(mappedBy = "spot")
     private List<Bookmark> bookmarks = new ArrayList<>();
-
+    @Column(nullable = false)
     private String spotName;
-
+    @Column(nullable = false)
     private String longitude;
+    @Column(nullable = false)
     private String latitude;
+    @Column(nullable = false)
     private String review;
 
     private Long likes;

--- a/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
@@ -1,0 +1,48 @@
+package com.cona.KUsukKusuk.spot.domain;
+
+import com.cona.KUsukKusuk.bookmark.domain.Bookmark;
+import com.cona.KUsukKusuk.comment.Comment;
+import com.cona.KUsukKusuk.global.domain.BaseEntity;
+import com.cona.KUsukKusuk.like.UserLike;
+import com.cona.KUsukKusuk.picture.Picture;
+import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class Spot extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @OneToMany(mappedBy = "spot")
+    private List<UserLike> userLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "spot")
+    private List<Picture> pictures = new ArrayList<>();
+
+    @OneToMany(mappedBy = "spot")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "spot")
+    private List<Bookmark> bookmarks = new ArrayList<>();
+
+    private String spotName;
+
+    private String longitude;
+    private String latitude;
+    private String review;
+
+    private Long like;
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -27,7 +27,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String email;
 
     @OneToMany(mappedBy = "user")

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -14,7 +14,7 @@ import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
+@Entity(name = "user")
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -1,0 +1,44 @@
+package com.cona.KUsukKusuk.user.domain;
+
+import com.cona.KUsukKusuk.bookmark.domain.Bookmark;
+import com.cona.KUsukKusuk.comment.Comment;
+import com.cona.KUsukKusuk.global.domain.BaseEntity;
+import com.cona.KUsukKusuk.like.UserLike;
+import com.cona.KUsukKusuk.spot.domain.Spot;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String username;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String email;
+
+    @OneToMany(mappedBy = "user")
+   private List<Bookmark> bookmarks = new ArrayList<>();
+    @OneToMany(mappedBy = "user")
+    private List<UserLike> userLikes = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user")
+    private List<Spot> spots = new ArrayList<>();
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create-drop
 
 logging:
   level:


### PR DESCRIPTION
기존 ERD의 테이블을 ORM 패러다임에 맞게 객체 연관관계 매핑을 하였습니다.
기본적으로 

1. 다대일 단방향
2. 필요할경우 다대일 양방향 추가

하는 전략으로 연관관계를 설정하였습니다.
또한 BaseEntity를 적용하여서 유저,댓글,장소 등이 생성된 시간과 수정된 시간을 기록할수 있도록 만들었습니다.
또한 지연로딩 을 설정하여 연관관계에 있지만 실제 사용하지 않는 객체를 찾아오지 않게 하였습니다.
like 예약어가 마리아DB 내의 예약어가 일치하여 DDL이 설정되지 않는 오류를 수정하였습니다.
