### PR TITLE
➕[Feat] : BaseResponse 설계

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/global/controller/Health.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/controller/Health.java
@@ -1,0 +1,18 @@
+package com.cona.KUsukKusuk.global.controller;
+
+import com.cona.KUsukKusuk.global.dto.HealthResponse;
+import com.cona.KUsukKusuk.global.response.HttpResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class Health {
+    @GetMapping("/health")
+    public HttpResponse<HealthResponse> healthCheck() {
+
+        return new HttpResponse<>(HttpStatus.OK,
+                HealthResponse.from("HTTP 상태 정상"));
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/controller/Health.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/controller/Health.java
@@ -12,7 +12,6 @@ public class Health {
     @GetMapping("/health")
     public HttpResponse<HealthResponse> healthCheck() {
 
-        return new HttpResponse<>(HttpStatus.OK,
-                HealthResponse.from("HTTP 상태 정상"));
+        return HttpResponse.okBuild(HealthResponse.from("HTTP 상태 정상"));
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/dto/HealthResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/dto/HealthResponse.java
@@ -1,0 +1,15 @@
+package com.cona.KUsukKusuk.global.dto;
+
+import lombok.Builder;
+
+@Builder
+public record HealthResponse(String message) {
+    public static HealthResponse from(
+            String message) {
+
+        return HealthResponse.builder()
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/response/ApiResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/response/ApiResponse.java
@@ -1,0 +1,4 @@
+package com.cona.KUsukKusuk.global.response;
+
+public record ApiResponse<T>(int staus, T results) {
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/response/HttpResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/response/HttpResponse.java
@@ -1,0 +1,18 @@
+package com.cona.KUsukKusuk.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+
+@JsonInclude(Include.NON_NULL)
+public class HttpResponse<T> extends ResponseEntity<ApiResponse<T>> {
+    //Todo:컨트롤러 하드코딩으로 Status값 생성이아니라 매서드로 보내기
+    public HttpResponse(HttpStatusCode status) {
+        super(status);
+    }
+    public HttpResponse(HttpStatusCode status, T reuslts) {
+        super(new ApiResponse<>(status.value(), reuslts), status);
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/response/HttpResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/response/HttpResponse.java
@@ -9,6 +9,9 @@ import org.springframework.http.ResponseEntity;
 @JsonInclude(Include.NON_NULL)
 public class HttpResponse<T> extends ResponseEntity<ApiResponse<T>> {
     //Todo:컨트롤러 하드코딩으로 Status값 생성이아니라 매서드로 보내기
+    public static <T> HttpResponse<T> okBuild(T body) {
+        return new HttpResponse<>(HttpStatus.OK, body);
+    }
     public HttpResponse(HttpStatusCode status) {
         super(status);
     }


### PR DESCRIPTION
우리 서비스의 BaseResponse를 설계하였습니다. 
세부 포맷은 
``` json
{
    "staus": 200,
    "results": {
        //DTO의 내용
    }
}
```
으로 했습니다. 실제 컨트롤러에서 전송하는 클래스는 `ResponseEntity<ApiContent<T>>`를 상속받는 HttpResponse로 구현하였고, 빌더 패턴으로 Status Code별로 생성되도록 구현하면 좋을거 같아서 예시로 OK 200 코드를 만들어 보았습니다.

추가로 DTO는 해당 Api 테스트 용도로 네트워크 health체크 컨트롤러로 테스트 완료하였습니다.
각 DTO 별로 정적팩토리 매서드인 `from`을 적용해 보았습니다. 네이밍 컨벤션은 
```
from : 하나의 매개 변수를 받아서 객체를 생성
of : 여러개의 매개 변수를 받아서 객체를 생성
getInstance | instance : 인스턴스를 생성. 이전에 반환했던 것과 같을 수 있음
newInstance | create : 항상 새로운 인스턴스를 생성
get[OrderType] : 다른 타입의 인스턴스를 생성. 이전에 반환했던 것과 같을 수 있음
new[OrderType] : 항상 다른 타입의 새로운 인스턴스를 생성

``` 을 따르면 좋을거 같습니다 !! ㅎㅎ 