### PR TITLE
⚙️[chore] : 스웨거 문서화 설정 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
+	//스웨거
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cona/KUsukKusuk/global/config/Swagger.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/config/Swagger.java
@@ -1,0 +1,27 @@
+package com.cona.KUsukKusuk.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+        info = @Info(title = "쿠석쿠석",
+                description = "KusukKusuk API 명세서 입니다.",
+                version = "v1"))
+@RequiredArgsConstructor
+@Configuration
+public class Swagger {
+    //http://localhost:8080/swagger-ui/index.html#/
+    @Bean
+    public GroupedOpenApi chatOpenApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("쿠석쿠석 API v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/controller/NetworkController.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/controller/NetworkController.java
@@ -2,14 +2,14 @@ package com.cona.KUsukKusuk.global.controller;
 
 import com.cona.KUsukKusuk.global.dto.HealthResponse;
 import com.cona.KUsukKusuk.global.response.HttpResponse;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-public class Health {
+public class NetworkController {
     @GetMapping("/health")
+    @Operation(summary = "네트워크 상태", description = "현재 네트워크 정상이면 200 코드를 반환합니다.")
     public HttpResponse<HealthResponse> healthCheck() {
 
         return HttpResponse.okBuild(HealthResponse.from("HTTP 상태 정상"));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
 logging:
   level:


### PR DESCRIPTION
스웨거 문서화 설정을 추가하였습니다.

팀이 소통하는데 스웨거를 사용하면 API 변화를 프론트엔드 분들과 잘 이야기 나눌수 있을거 같아서 문서화를 해보았습니다.
Spring 3.0 부터는`springdoc-openapi`에서 지원하는 스웨거 사용을 추천한다고 해서 해당 버전으로 설치하였습니다. 
스웨거 간단한 사용법은 제가 `health-check Controller`에 예시로 남겼으니 해당 부분 보시면 조금더 수월하게 익히실수 있을 거 같습니다 !! 