### PR TITLE
➕ [Feat] : JWT 발급 기능과 회원가입 로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,11 @@ dependencies {
 	//restdocs 의존성 추가
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
+	//jwt 의존성 추가
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,13 @@ dependencies {
 	//스웨거
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 
+	//@notnull Validate 기능 활성화
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	//Test코드에 @slf4j 사용
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+
 }
 
 tasks.named('test') {
@@ -44,3 +51,4 @@ tasks.named('test') {
 jar{
 	enabled =false
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 
+	//restdocs 의존성 추가
+	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cona/KUsukKusuk/KuSukKuSukApplication.java
+++ b/src/main/java/com/cona/KUsukKusuk/KuSukKuSukApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(exclude = SecurityAutoConfiguration.class)
+@SpringBootApplication
 public class KuSukKuSukApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/cona/KUsukKusuk/bookmark/domain/Bookmark.java
+++ b/src/main/java/com/cona/KUsukKusuk/bookmark/domain/Bookmark.java
@@ -8,8 +8,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 public class Bookmark {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cona/KUsukKusuk/comment/Comment.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/Comment.java
@@ -10,8 +10,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
 public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cona/KUsukKusuk/global/security/CustomUserDetails.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/CustomUserDetails.java
@@ -1,0 +1,59 @@
+package com.cona.KUsukKusuk.global.security;
+
+import com.cona.KUsukKusuk.user.domain.User;
+import java.util.ArrayList;
+import java.util.Collection;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+    private final User user;
+
+    public CustomUserDetails(User user) {
+
+        this.user = user;
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+
+        return user.getUserId();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+
+        return true;
+    }
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/CustomUserDetailsService.java
@@ -1,0 +1,31 @@
+package com.cona.KUsukKusuk.global.security;
+
+import com.cona.KUsukKusuk.user.domain.User;
+import com.cona.KUsukKusuk.user.repository.UserRepository;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+
+        User user = userRepository.findByUserId(username);
+
+        if (user != null) {
+
+            return new CustomUserDetails(user);
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -1,0 +1,47 @@
+package com.cona.KUsukKusuk.global.security;
+
+import io.jsonwebtoken.Jwts;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUserId(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("userid", String.class);
+    }
+
+    public String getPassword(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("password", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String createJwt(String userid, String password, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("userid", userid)
+                .claim("password", password)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -1,0 +1,42 @@
+package com.cona.KUsukKusuk.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+public class LoginFilter extends UsernamePasswordAuthenticationFilter {
+
+    private final AuthenticationManager authenticationManager;
+
+    public LoginFilter(AuthenticationManager authenticationManager) {
+
+        this.authenticationManager = authenticationManager;
+    }
+
+    @Override
+    public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response) throws AuthenticationException {
+
+        //클라이언트 요청에서 username, password 추출
+        String username = obtainUsername(request);
+        String password = obtainPassword(request);
+
+        UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
+
+        return authenticationManager.authenticate(authToken);
+    }
+
+    @Override
+    protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
+
+    }
+
+    @Override
+    protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
+
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -30,6 +30,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         //클라이언트 요청에서 username, password 추출
         String username = obtainUsername(request);
         String password = obtainPassword(request);
+        logger.info("추출한 username : "+username);
+        logger.info("추출한 비밀번호 : "+password);
 
         UsernamePasswordAuthenticationToken authToken = new UsernamePasswordAuthenticationToken(username, password, null);
 
@@ -55,5 +57,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest request, HttpServletResponse response, AuthenticationException failed) {
 
+        response.setStatus(401);
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -3,19 +3,25 @@ package com.cona.KUsukKusuk.global.security;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Collection;
+import java.util.Iterator;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
 
-    public LoginFilter(AuthenticationManager authenticationManager) {
+    private final JWTUtil jwtUtil;
+
+    public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
 
         this.authenticationManager = authenticationManager;
+        this.jwtUtil=jwtUtil;
     }
 
     @Override
@@ -33,6 +39,17 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     protected void successfulAuthentication(HttpServletRequest request, HttpServletResponse response, FilterChain chain, Authentication authentication) {
 
+        //UserDetailsS
+        CustomUserDetails customUserDetails = (CustomUserDetails) authentication.getPrincipal();
+
+        String username = customUserDetails.getUsername();
+
+
+        String password = customUserDetails.getPassword();
+
+        String token = jwtUtil.createJwt(username, password, 60*60*100L);
+
+        response.addHeader("Authorization", "Bearer " + token);
     }
 
     @Override

--- a/src/main/java/com/cona/KUsukKusuk/global/security/MainController.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/MainController.java
@@ -1,0 +1,30 @@
+package com.cona.KUsukKusuk.global.security;
+
+import io.swagger.v3.oas.annotations.Operation;
+import java.util.Collection;
+import java.util.Iterator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@ResponseBody
+public class MainController {
+    @GetMapping("/userinfo")
+    @Operation
+    public String main() {
+        String username= SecurityContextHolder.getContext().getAuthentication()
+                .getName();
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+
+        return "현재 접속자명 : "+username + "접속자 비밀번호 : "+role;
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -1,7 +1,9 @@
 package com.cona.KUsukKusuk.global.security;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -11,7 +13,11 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final AuthenticationConfiguration authenticationConfiguration;
+
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.cona.KUsukKusuk.global.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -18,6 +19,13 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
 
+
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+
+        return configuration.getAuthenticationManager();
+    }
 
     @Bean
     public BCryptPasswordEncoder bCryptPasswordEncoder() {

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -54,7 +54,9 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/login", "/", "/join","/health").permitAll()
+                        .requestMatchers("/users/login", "/userinfo", "/users/join","/health").permitAll()
+                        .requestMatchers( "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                        //스웨거 접근권한 허용
                         .anyRequest().authenticated());
 
         http

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -1,0 +1,42 @@
+package com.cona.KUsukKusuk.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //http basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/login", "/", "/join","/health").permitAll()
+                        .anyRequest().authenticated());
+
+        //세션 설정
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -37,6 +38,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests((auth) -> auth
                         .requestMatchers("/login", "/", "/join","/health").permitAll()
                         .anyRequest().authenticated());
+
+        http
+                .addFilterAt(new LoginFilter(), UsernamePasswordAuthenticationFilter.class);
+
 
         //세션 설정
         http

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -14,10 +14,16 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @Configuration
 @EnableWebSecurity
-@RequiredArgsConstructor
 public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
+
+    private final JWTUtil jwtUtil;
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration,JWTUtil jwtUtil) {
+
+        this.authenticationConfiguration = authenticationConfiguration;
+        this.jwtUtil = jwtUtil;
+    }
 
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
@@ -52,7 +58,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated());
 
         http
-                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration),jwtUtil), UsernamePasswordAuthenticationFilter.class);
 
 
         //세션 설정

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -19,8 +19,6 @@ public class SecurityConfig {
 
     private final AuthenticationConfiguration authenticationConfiguration;
 
-
-
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
 
@@ -54,7 +52,7 @@ public class SecurityConfig {
                         .anyRequest().authenticated());
 
         http
-                .addFilterAt(new LoginFilter(), UsernamePasswordAuthenticationFilter.class);
+                .addFilterAt(new LoginFilter(authenticationManager(authenticationConfiguration)), UsernamePasswordAuthenticationFilter.class);
 
 
         //세션 설정

--- a/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/SecurityConfig.java
@@ -5,11 +5,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+
+        return new BCryptPasswordEncoder();
+    }
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 

--- a/src/main/java/com/cona/KUsukKusuk/like/UserLike.java
+++ b/src/main/java/com/cona/KUsukKusuk/like/UserLike.java
@@ -9,8 +9,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity(name = "user_like")
+@NoArgsConstructor
+@AllArgsConstructor
 public class UserLike {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cona/KUsukKusuk/picture/Picture.java
+++ b/src/main/java/com/cona/KUsukKusuk/picture/Picture.java
@@ -9,8 +9,12 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 public class Picture {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
@@ -17,8 +17,12 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
+@AllArgsConstructor
 public class Spot extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -21,8 +21,7 @@ public class UserController {
 
     @PostMapping("/join")
     public HttpResponse<UserJoinResponse> join(@Valid @RequestBody UserJoinRequest userJoinRequest) {
-        User user = userJoinRequest.toEntity();
-        User savedUser = userService.save(user);
+        User savedUser = userService.save(userJoinRequest);
         return HttpResponse.okBuild(
                 UserJoinResponse.of(savedUser)
         );

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -1,0 +1,12 @@
+package com.cona.KUsukKusuk.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("users")
+@RequiredArgsConstructor
+public class UserController {
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -1,7 +1,15 @@
 package com.cona.KUsukKusuk.user.controller;
 
+import com.cona.KUsukKusuk.global.response.HttpResponse;
+import com.cona.KUsukKusuk.user.domain.User;
+import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
+import com.cona.KUsukKusuk.user.dto.UserJoinResponse;
+import com.cona.KUsukKusuk.user.service.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -9,4 +17,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("users")
 @RequiredArgsConstructor
 public class UserController {
+    private final UserService userService;
+
+    @PostMapping("/join")
+    public HttpResponse<UserJoinResponse> join(@Valid @RequestBody UserJoinRequest userJoinRequest) {
+        User user = userJoinRequest.toEntity();
+        User savedUser = userService.save(user);
+        return HttpResponse.okBuild(
+                UserJoinResponse.of(savedUser)
+        );
+    }
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -17,10 +17,12 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity(name = "user")
 @Builder
 @Getter
+@Setter
 @NoArgsConstructor
 @AllArgsConstructor
 public class User extends BaseEntity {
@@ -38,6 +40,8 @@ public class User extends BaseEntity {
     private String email;
     @Column(nullable = false)
     private String nickname;
+
+    private String noCryptpassword;
 
     @OneToMany(mappedBy = "user")
    private List<Bookmark> bookmarks = new ArrayList<>();

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -13,8 +13,12 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
 
 @Entity(name = "user")
+@Builder
+@Getter
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -13,12 +13,16 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity(name = "user")
 @Builder
 @Getter
+@NoArgsConstructor
+@AllArgsConstructor
 public class User extends BaseEntity {
 
     @Id

--- a/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/domain/User.java
@@ -22,13 +22,14 @@ public class User extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private String username;
+    private String userId;
 
     @Column(nullable = false)
     private String password;
-
     @Column(nullable = true)
     private String email;
+    @Column(nullable = false)
+    private String nickname;
 
     @OneToMany(mappedBy = "user")
    private List<Bookmark> bookmarks = new ArrayList<>();

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinRequest.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinRequest.java
@@ -26,6 +26,7 @@ public record UserJoinRequest(
                         .password(password)
                         .email(email)
                         .nickname(nickname)
+                        .noCryptpassword(password)
                         .build();
         }
 

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinRequest.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinRequest.java
@@ -1,5 +1,6 @@
 package com.cona.KUsukKusuk.user.dto;
 
+import com.cona.KUsukKusuk.user.domain.User;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
@@ -19,5 +20,13 @@ public record UserJoinRequest(
         String nickname
 )
 {
+        public User toEntity() {
+                return User.builder()
+                        .userId(userId)
+                        .password(password)
+                        .email(email)
+                        .nickname(nickname)
+                        .build();
+        }
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinRequest.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinRequest.java
@@ -1,0 +1,23 @@
+package com.cona.KUsukKusuk.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record UserJoinRequest(
+
+        @NotNull(message = "사용자 아이디는 필수 입력값입니다.")
+        @Schema(description = "사용자 아이디", nullable = false, example = "")
+        String userId,
+        @NotNull(message = "사용자 비밀번호는 필수 입력값입니다.")
+        @Schema(description = "사용자 비밀번호", nullable = false, example = "")
+        String password,
+        @NotNull(message = "사용자 이메일은 필수 입력값입니다.")
+        @Schema(description = "사용자 이메일", nullable = false, example = "")
+        String email,
+        @NotNull(message = "사용자 닉네임은 필수 입력값입니다.")
+        @Schema(description = "사용자 아이디", nullable = false, example = "")
+        String nickname
+)
+{
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserJoinResponse.java
@@ -1,0 +1,19 @@
+package com.cona.KUsukKusuk.user.dto;
+
+import com.cona.KUsukKusuk.user.domain.User;
+import lombok.Builder;
+
+@Builder
+public record UserJoinResponse(
+        Long id, String userid,String password,String email,String nickname
+) {
+    public static UserJoinResponse of(User user){
+        return UserJoinResponse.builder()
+                .id(user.getId())
+                .userid(user.getUserId())
+                .password(user.getPassword())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .build();
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/repository/UserRepository.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/repository/UserRepository.java
@@ -1,8 +1,14 @@
 package com.cona.KUsukKusuk.user.repository;
 
 import com.cona.KUsukKusuk.user.domain.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByUserId(String userid);
+
+    boolean existsByNickname(String nickname);
+
+    boolean existsByEmail(String email);
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/repository/UserRepository.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByEmail(String email);
 
+    User findByUserId(String userid);
+
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/repository/UserRepository.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package com.cona.KUsukKusuk.user.repository;
+
+import com.cona.KUsukKusuk.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -1,0 +1,16 @@
+package com.cona.KUsukKusuk.user.service;
+
+import com.cona.KUsukKusuk.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+    private final UserRepository userRepository;
+
+    public void save() {
+
+    }
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.cona.KUsukKusuk.user.service;
 
+import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -9,8 +10,9 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
 
-    public void save() {
-
+    public User save(User user) {
+        User savedUser = userRepository.save(user);
+        return savedUser;
     }
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.cona.KUsukKusuk.user.service;
 
 import com.cona.KUsukKusuk.user.domain.User;
+import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,7 +11,8 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
 
-    public User save(User user) {
+    public User save(UserJoinRequest userJoinRequest) {
+        User user = userJoinRequest.toEntity();
         User savedUser = userRepository.save(user);
         return savedUser;
     }

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -4,16 +4,20 @@ import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
     private final UserRepository userRepository;
+    private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     public User save(UserJoinRequest userJoinRequest) {
         User user = userJoinRequest.toEntity();
+        user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
         User savedUser = userRepository.save(user);
+
         return savedUser;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
     database: mysql
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
   jwt:
     secret : ${jwt_secret}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,8 @@ spring:
     show-sql: true
     hibernate:
       ddl-auto: update
+  jwt:
+    secret : ${jwt_secret}
 
 logging:
   level:

--- a/src/test/java/com/cona/KUsukKusuk/fixture/UserFixture.java
+++ b/src/test/java/com/cona/KUsukKusuk/fixture/UserFixture.java
@@ -1,8 +1,49 @@
 package com.cona.KUsukKusuk.fixture;
 
+import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+
 public enum UserFixture {
 
     DEFAULT(
+            1L,
+            "konkuk",
+            "vdongv1620",
+            "donghoon141@naver.com",
+            "최동훈"
+    );
 
-    )
+
+    private Long id;
+
+    private String userId;
+
+    private String password;
+    private String email;
+    private String nickname;
+
+    UserFixture(Long id, String userId, String password, String email, String nickname) {
+        this.id = id;
+        this.userId = userId;
+        this.password = password;
+        this.email = email;
+        this.nickname = nickname;
+    }
+
+    public User getUser() {
+        return User.builder()
+                .id(id)
+                .userId(userId)
+                .password(password)
+                .email(email)
+                .nickname(nickname)
+                .build();
+    }
 }
+

--- a/src/test/java/com/cona/KUsukKusuk/fixture/UserFixture.java
+++ b/src/test/java/com/cona/KUsukKusuk/fixture/UserFixture.java
@@ -1,0 +1,8 @@
+package com.cona.KUsukKusuk.fixture;
+
+public enum UserFixture {
+
+    DEFAULT(
+
+    )
+}

--- a/src/test/java/com/cona/KUsukKusuk/support/RestDocsTest.java
+++ b/src/test/java/com/cona/KUsukKusuk/support/RestDocsTest.java
@@ -1,0 +1,36 @@
+package com.cona.KUsukKusuk.support;
+
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith( SpringExtension.class)
+@AutoConfigureRestDocs
+@ActiveProfiles("test")
+@WebMvcTest
+public class RestDocsTest {
+
+    @Autowired
+    private ObjectMapper objectMapper;
+    protected MockMvc mockMvc;
+
+    protected String toJson(Object value) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(value);
+    }
+
+}

--- a/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
+++ b/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
@@ -2,8 +2,11 @@ package com.cona.KUsukKusuk.user.controller;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.cona.KUsukKusuk.support.RestDocsTest;
+import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14,6 +17,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.session.MockitoSessionBuilder;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +28,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.validation.ObjectError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
@@ -32,7 +37,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 @ExtendWith(SpringExtension.class)
 @AutoConfigureMockMvc(addFilters = false)
 @Slf4j
-public class UserControllerTest {
+public class UserControllerTest extends RestDocsTest {
 
     @Autowired
     private MockMvc mockMvc;
@@ -50,7 +55,6 @@ public class UserControllerTest {
         UserJoinRequest userJoinRequest
                 = new UserJoinRequest(null, "vdongv1620", "email", "최동훈");
 
-
         //when
         MvcResult perform = mockMvc.perform(post("/users/join")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -63,6 +67,43 @@ public class UserControllerTest {
         assertThat(resolvedException).isInstanceOf(MethodArgumentNotValidException.class);
 
 //      assertThat(resolvedException.getMessage()).isEqualTo("사용자 아이디는 필수 입력 값입니다.");
+
+    }
+
+    @Test
+    @DisplayName("회원가입 성공시 User의 정보를 정해진 형식으로 반환한다.")
+    void join() throws Exception {
+        //given
+        UserJoinRequest userJoinRequest
+                = new UserJoinRequest("최동훈", "vdongv1620", "email", "최동훈");
+
+        User mockUser = User.builder()
+                .id(1L)
+                .userId("최동훈")
+                .password("vdongv1620")
+                .email("email")
+                .nickname("최동훈")
+                .build();
+
+        BDDMockito.given(userService.save(userJoinRequest)).willReturn(mockUser);
+
+        //when
+        ResultActions perform = mockMvc.perform(post("/users/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(toJson(userJoinRequest)));
+
+        //반환값 확인
+        MvcResult mvcResult = perform.andReturn();
+        String responseBody = mvcResult.getResponse().getContentAsString();
+        System.out.println("responseBody = " + responseBody);
+
+        //then
+        perform.andExpect(status().isOk())
+                .andExpect(jsonPath("$.results.id").value(1L))
+                .andExpect(jsonPath("$.results.userid").value("최동훈"))
+                .andExpect(jsonPath("$.results.password").value("vdongv1620"))
+                .andExpect(jsonPath("$.results.email").value("email"))
+                .andExpect(jsonPath("$.results.nickname").value("최동훈"));
 
 
     }

--- a/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
+++ b/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
@@ -50,7 +50,7 @@ public class UserControllerTest extends RestDocsTest {
     private UserService userService;
 
     @Test
-    @DisplayName("회원가입시 필수항목 null시 예외를 던진다")
+    @DisplayName("회원가입시 필수항목 null시 커스텀예외를 던진다")
     void join_exception_Test() throws Exception {
         //given
         UserJoinRequest userJoinRequest

--- a/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
+++ b/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
@@ -1,0 +1,69 @@
+package com.cona.KUsukKusuk.user.controller;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
+import com.cona.KUsukKusuk.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import javax.swing.Spring;
+import lombok.extern.slf4j.Slf4j;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.session.MockitoSessionBuilder;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+
+
+@WebMvcTest(UserController.class)
+@ExtendWith(SpringExtension.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Slf4j
+public class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("회원가입시 필수항목 null시 예외를 던진다")
+    void join_exception_Test() throws Exception {
+        //given
+        UserJoinRequest userJoinRequest
+                = new UserJoinRequest(null, "vdongv1620", "email", "최동훈");
+
+
+        //when
+        MvcResult perform = mockMvc.perform(post("/users/join")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(userJoinRequest)))
+                .andExpect(status().isBadRequest())
+                .andReturn();
+
+        //then
+        Exception resolvedException = perform.getResolvedException();
+        assertThat(resolvedException).isInstanceOf(MethodArgumentNotValidException.class);
+
+//      assertThat(resolvedException.getMessage()).isEqualTo("사용자 아이디는 필수 입력 값입니다.");
+
+
+    }
+}

--- a/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
+++ b/src/test/java/com/cona/KUsukKusuk/user/controller/UserControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.cona.KUsukKusuk.fixture.UserFixture;
 import com.cona.KUsukKusuk.support.RestDocsTest;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
@@ -75,15 +76,9 @@ public class UserControllerTest extends RestDocsTest {
     void join() throws Exception {
         //given
         UserJoinRequest userJoinRequest
-                = new UserJoinRequest("최동훈", "vdongv1620", "email", "최동훈");
+                = new UserJoinRequest("konkuk", "vdongv1620", "donghoon141@naver.com", "최동훈");
 
-        User mockUser = User.builder()
-                .id(1L)
-                .userId("최동훈")
-                .password("vdongv1620")
-                .email("email")
-                .nickname("최동훈")
-                .build();
+        User mockUser = UserFixture.DEFAULT.getUser();
 
         BDDMockito.given(userService.save(userJoinRequest)).willReturn(mockUser);
 
@@ -100,9 +95,9 @@ public class UserControllerTest extends RestDocsTest {
         //then
         perform.andExpect(status().isOk())
                 .andExpect(jsonPath("$.results.id").value(1L))
-                .andExpect(jsonPath("$.results.userid").value("최동훈"))
+                .andExpect(jsonPath("$.results.userid").value("konkuk"))
                 .andExpect(jsonPath("$.results.password").value("vdongv1620"))
-                .andExpect(jsonPath("$.results.email").value("email"))
+                .andExpect(jsonPath("$.results.email").value("donghoon141@naver.com"))
                 .andExpect(jsonPath("$.results.nickname").value("최동훈"));
 
 

--- a/src/test/java/com/cona/KUsukKusuk/user/service/UserServiceTest.java
+++ b/src/test/java/com/cona/KUsukKusuk/user/service/UserServiceTest.java
@@ -1,0 +1,43 @@
+package com.cona.KUsukKusuk.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.cona.KUsukKusuk.user.domain.User;
+import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
+import com.cona.KUsukKusuk.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    UserService userService;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    User user;
+
+    @Test
+    @DisplayName("유저 DTO를받아서 DB에저장한다.")
+    void save() {
+        UserJoinRequest userJoinRequest
+                = new UserJoinRequest("donghun", "vdongv1620", "email", "최동훈");
+
+        user = userJoinRequest.toEntity();
+        BDDMockito.given(userRepository.save(any(User.class)))
+                .willReturn(user);
+
+        User savedUser = userService.save(userJoinRequest);
+
+        Assertions.assertThat(savedUser).isEqualTo(user);
+
+    }
+}


### PR DESCRIPTION
### 요약  
1. 사용자의 회원가입기능과 로그인시 JWT 발급 기능을 구현하였습니다.
2.  회원가입 기능의 테스트 코드를 메서드별로 모두 작성하였습니다.

### 세부사항

DTO인 UserJoinRequest의 필수 필드값이 빠져있을 경우, `MethodArgumentNotValidException.class` 예외가  발생되도록 구현하였습니다. 
해당 예외는 로그인 기능 완성후 커스텀 예외 처리 할때 handler 생성후 처리할 예정입니다.
회원가입이 성공하면 회원의 비밀번호는  `BCryptPasswordEncoder` 를 통하여 암호화된채로 DB에 저장되도록 구현하였습니다. 

해당 방법이 `SpringSecurity 6.0 `부터 공식적으로 추천하는 옵션이라서 해당 암호화 기법을 사용하였습니다.
또한 로그인 성공시 AT의 유효시간은 36000MS 로 설정하였고, 토큰속에는 사용자의 아이디와 비밀번호를 담도록 설계하였습니다.
현재는 토큰 발급 기능까지 구현하였고 추가적으로 발급된 토큰을 Resolve하는 JWT 검증 기능을 구현할 예정입니다. 

