### PR TITLE
➕ [Feat] :  Redis 에 RefreshToken 저장 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
+	//redis 의존성 추가
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cona/KUsukKusuk/global/redis/RedisConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/redis/RedisConfig.java
@@ -1,0 +1,33 @@
+package com.cona.KUsukKusuk.global.redis;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host, port);
+    }
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+
+        return redisTemplate;
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -44,4 +44,15 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
     }
+    public String createRefreshToken(String userid, String password, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("userid", userid)
+                .claim("password", password)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -3,14 +3,23 @@ package com.cona.KUsukKusuk.global.security;
 import io.jsonwebtoken.Jwts;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
 
 @Component
 public class JWTUtil {
 
+    @Autowired
+    private  RedisTemplate<String, String> redisTemplate;
     private SecretKey secretKey;
 
     public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
@@ -46,13 +55,26 @@ public class JWTUtil {
     }
     public String createRefreshToken(String userid, String password, Long expiredMs) {
 
-        return Jwts.builder()
+
+        String refreshToken = Jwts.builder()
                 .claim("userid", userid)
                 .claim("password", password)
                 .issuedAt(new Date(System.currentTimeMillis()))
                 .expiration(new Date(System.currentTimeMillis() + expiredMs))
                 .signWith(secretKey)
                 .compact();
+
+        // redis에 저장
+        redisTemplate.opsForValue().set(
+                userid,
+                refreshToken,
+                expiredMs,
+                TimeUnit.MILLISECONDS
+        );
+
+
+
+        return refreshToken;
     }
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -48,10 +48,14 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
 
         String password = customUserDetails.getPassword();
+        //AT : 6분
+        String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
+        //RT : 7일
+        String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
 
-        String token = jwtUtil.createJwt(username, password, 60*60*100L);
+        response.addHeader("Authorization", "Bearer " + accessToken);
+        response.addHeader("RefreshToken","Bearer "+refreshToken);
 
-        response.addHeader("Authorization", "Bearer " + token);
     }
 
     @Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,11 @@ spring:
   jwt:
     secret : ${jwt_secret}
 
+  data:
+    redis:
+      host: localhost
+      port: 6379
+
 logging:
   level:
     org.hibernate.SQL: info


### PR DESCRIPTION
### 요약  

1. 리프레시토큰을 발급하는 기능을 구현하였습니다.
2. 발급 refreshToken을 레디스에 저장하는 기능을 구현하였습니다.
---

### 세부내용 
우선 리프레시토큰은 앞전에 발행한 `AccessToken` 과 달리 7일을 주기로 발급하도록 구현하였고, 해당 발급 토큰 모두 `Http` 응답값의 `header`에 넣은채로 반환되도록 구현하였습니다. 

 또한 만약 만기가 긴 `refreshtoken`이 탈취될 경우를 대비하여 서버에서 컨트롤 가능해야 함으로, 서버에 저장하는 방법을 택했습니다.  해더에 넣은 이유는  `Body`보다는 `header`에 넣는 **관습**(컨벤션) 이 있다 하여서 그렇게 구현하였습니다.

  **RDB**에 저장하는것이 아닌 **레디스**를 선택한 이유는  I/O가 빈번한 데이터를 저장할 때 사용하기 좋다는 점과 운영 중인 웹 서버에서 `key-value` 형태의 데이터 타입을 처리해야 할 때 사용하기 적합하기 때문에 선택하였습니다.


   `key-value` 값 발행당시 사용자 아이디와 리프레시토큰을 저장하도록 구현하였습니다. 
![image](https://github.com/KONKUK-MAP-Service/Ku-suk-Ku-suk/assets/58305106/f2976f63-9666-46f3-aa97-60b0f3434295)


---
 
### 추후 개발 사항 
1. 레디스 사용 기능 조금더 보기좋게 깔끔하게 `RedisTemplate` 을 주입받아 별도의 class를 만들어 리팩토링 할 예정입니다.
2. 로그아웃시 레디스 에 저장된 `refreshtoken`을 블랙리스트 처리하는 방식을 고려중입니다.
3. 보안점으로, 래디스에 저장된 **토큰 자체**가 탈취당할 경우 대응방안을 마련할 예정입니다.. 