### PR TITLE
➕ [Feat] : 로그아웃 토큰 블랙리스트 처리기능 구현

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/exception/HttpExceptionCode.java
@@ -10,9 +10,10 @@ public enum HttpExceptionCode {
 
 
 
-    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다.");
+    INVALID_ARGUMENT(HttpStatus.BAD_REQUEST,  "올바르지 않은 값이 전달되었습니다."),
 
 
+    JWT_NOT_FOUND(HttpStatus.UNAUTHORIZED, "JWT를 찾을 수 없습니다.");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/cona/KUsukKusuk/global/exception/custom/security/SecurityJwtNotFoundException.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/exception/custom/security/SecurityJwtNotFoundException.java
@@ -1,0 +1,22 @@
+package com.cona.KUsukKusuk.global.exception.custom.security;
+
+import com.cona.KUsukKusuk.global.exception.HttpExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@Setter
+@Slf4j
+public class SecurityJwtNotFoundException extends RuntimeException {
+    private final HttpStatus httpStatus;
+    public SecurityJwtNotFoundException(HttpExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+        this.httpStatus=exceptionCode.getHttpStatus();
+    }
+
+
+    public SecurityJwtNotFoundException(){
+        this(HttpExceptionCode.JWT_NOT_FOUND);}
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/exception/handler/security/SecurityExceptionHandler.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/exception/handler/security/SecurityExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.cona.KUsukKusuk.global.exception.handler.security;
+
+import com.cona.KUsukKusuk.global.exception.custom.security.SecurityJwtNotFoundException;
+import com.cona.KUsukKusuk.global.response.ErrorResponse;
+import com.cona.KUsukKusuk.global.response.HttpResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+@Order(Ordered.LOWEST_PRECEDENCE)
+public class SecurityExceptionHandler {
+
+    @ExceptionHandler(SecurityJwtNotFoundException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public HttpResponse<ErrorResponse> securityExceptionHandler(SecurityJwtNotFoundException e) {
+        return HttpResponse.status(e.getHttpStatus())
+                .body(ErrorResponse.from(e.getHttpStatus(), e.getMessage()));
+
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/redis/RedisConfig.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/redis/RedisConfig.java
@@ -22,8 +22,8 @@ public class RedisConfig {
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
         redisTemplate.setConnectionFactory(redisConnectionFactory());

--- a/src/main/java/com/cona/KUsukKusuk/global/redis/RedisService.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/redis/RedisService.java
@@ -1,0 +1,68 @@
+package com.cona.KUsukKusuk.global.redis;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+
+public class RedisService {
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void setValues(String key, String data) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data);
+    }
+
+    public void setValues(String key, String data, Duration duration) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        values.set(key, data, duration);
+    }
+
+    @Transactional(readOnly = true)
+    public String getValues(String key) {
+        ValueOperations<String, Object> values = redisTemplate.opsForValue();
+        if (values.get(key) == null) {
+            return "false";
+        }
+        return (String) values.get(key);
+    }
+
+    public void deleteValues(String key) {
+        redisTemplate.delete(key);
+    }
+
+    public void expireValues(String key, int timeout) {
+        redisTemplate.expire(key, timeout, TimeUnit.MILLISECONDS);
+    }
+
+    public void setHashOps(String key, Map<String, String> data) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.putAll(key, data);
+    }
+
+    @Transactional(readOnly = true)
+    public String getHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        return Boolean.TRUE.equals(values.hasKey(key, hashKey)) ? (String) redisTemplate.opsForHash().get(key, hashKey) : "";
+    }
+
+    public void deleteHashOps(String key, String hashKey) {
+        HashOperations<String, Object, Object> values = redisTemplate.opsForHash();
+        values.delete(key, hashKey);
+    }
+
+    public boolean checkExistsValue(String value) {
+        return !value.equals("false");
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -83,7 +83,7 @@ public class JWTUtil {
         return refreshToken;
     }
     // Request Header에 Access Token 정보를 추출하는 메서드
-    public String resolveAccessToken(HttpServletRequest request) {
+    public String getAccessToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
             return bearerToken.substring(7);
@@ -92,7 +92,7 @@ public class JWTUtil {
     }
 
     // Request Header에 Refresh Token 정보를 추출하는 메서드
-    public String resolveRefreshToken(HttpServletRequest request) {
+    public String getRefreshToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(REFRESH_HEADER);
         if (StringUtils.hasText(bearerToken)) {
             return bearerToken;

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -70,16 +70,6 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
 
-        // redis에 저장
-        redisTemplate.opsForValue().set(
-                userid,
-                refreshToken,
-                expiredMs,
-                TimeUnit.MILLISECONDS
-        );
-
-
-
         return refreshToken;
     }
     // Request Header에 Access Token 정보를 추출하는 메서드

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -1,6 +1,7 @@
 package com.cona.KUsukKusuk.global.security;
 
 import io.jsonwebtoken.Jwts;
+import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.Map;
@@ -14,9 +15,14 @@ import org.springframework.data.redis.core.HashOperations;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
 @Component
 public class JWTUtil {
+    public static final String BEARER_TYPE = "Bearer";
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String REFRESH_HEADER = "RefreshToken";
+    public static final String BEARER_PREFIX = "Bearer ";
 
     @Autowired
     private  RedisTemplate<String, String> redisTemplate;
@@ -75,6 +81,23 @@ public class JWTUtil {
 
 
         return refreshToken;
+    }
+    // Request Header에 Access Token 정보를 추출하는 메서드
+    public String resolveAccessToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // Request Header에 Refresh Token 정보를 추출하는 메서드
+    public String resolveRefreshToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(REFRESH_HEADER);
+        if (StringUtils.hasText(bearerToken)) {
+            return bearerToken;
+        }
+        return null;
     }
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/JWTUtil.java
@@ -1,5 +1,6 @@
 package com.cona.KUsukKusuk.global.security;
 
+import com.cona.KUsukKusuk.global.redis.RedisService;
 import io.jsonwebtoken.Jwts;
 import jakarta.servlet.http.HttpServletRequest;
 import java.nio.charset.StandardCharsets;
@@ -25,7 +26,7 @@ public class JWTUtil {
     public static final String BEARER_PREFIX = "Bearer ";
 
     @Autowired
-    private  RedisTemplate<String, String> redisTemplate;
+    private RedisService redisService;
     private SecretKey secretKey;
 
     public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
@@ -70,6 +71,9 @@ public class JWTUtil {
                 .signWith(secretKey)
                 .compact();
 
+        // redis에 RT저장
+        redisService.setValues(userid,refreshToken);
+
         return refreshToken;
     }
     // Request Header에 Access Token 정보를 추출하는 메서드
@@ -85,7 +89,7 @@ public class JWTUtil {
     public String getRefreshToken(HttpServletRequest request) {
         String bearerToken = request.getHeader(REFRESH_HEADER);
         if (StringUtils.hasText(bearerToken)) {
-            return bearerToken;
+            return bearerToken.substring(7);
         }
         return null;
     }

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -16,15 +16,12 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.stereotype.Component;
 
-@Component
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
 
     private final JWTUtil jwtUtil;
 
-    @Autowired
-    private RedisService redisService;
 
     public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
 
@@ -61,8 +58,6 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         //RT : 7일
         String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
 
-        // redis에 RT저장
-        redisService.setValues(username,refreshToken);
 
         response.addHeader("Authorization", "Bearer " + accessToken);
         response.addHeader("RefreshToken","Bearer "+refreshToken);

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -1,22 +1,30 @@
 package com.cona.KUsukKusuk.global.security;
 
+import com.cona.KUsukKusuk.global.redis.RedisService;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.stereotype.Component;
 
+@Component
 public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
     private final AuthenticationManager authenticationManager;
 
     private final JWTUtil jwtUtil;
+
+    @Autowired
+    private RedisService redisService;
 
     public LoginFilter(AuthenticationManager authenticationManager, JWTUtil jwtUtil) {
 
@@ -52,6 +60,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
         //RT : 7일
         String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
+
+        // redis에 RT저장
+        redisService.setValues(username,refreshToken);
 
         response.addHeader("Authorization", "Bearer " + accessToken);
         response.addHeader("RefreshToken","Bearer "+refreshToken);

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
         );
     }
     @PatchMapping("/logout")
-    public ResponseEntity logout(HttpServletRequest request) {
+    public HttpResponse logout(HttpServletRequest request) {
         String encryptedRefreshToken = jwtUtil.getRefreshToken(request);
         String accessToken = jwtUtil.getAccessToken(request);
         userService.logout(encryptedRefreshToken, accessToken);

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -5,12 +5,14 @@ import com.cona.KUsukKusuk.global.security.JWTUtil;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.dto.UserJoinResponse;
+import com.cona.KUsukKusuk.user.dto.UserLogoutResponse;
 import com.cona.KUsukKusuk.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -33,11 +35,16 @@ public class UserController {
         );
     }
     @PatchMapping("/logout")
-    public HttpResponse logout(HttpServletRequest request) {
+    public HttpResponse<UserLogoutResponse> logout(HttpServletRequest request) {
+
+        String username= SecurityContextHolder.getContext().getAuthentication()
+                .getName();
         String encryptedRefreshToken = jwtUtil.getRefreshToken(request);
         String accessToken = jwtUtil.getAccessToken(request);
-        userService.logout(encryptedRefreshToken, accessToken);
+        String blacklist = userService.logout(encryptedRefreshToken, accessToken);
 
-        return new ResponseEntity<>(new SingleResponseDto<>("Logged out successfully"), HttpStatus.NO_CONTENT);
+        return HttpResponse.okBuild(
+                UserLogoutResponse.from(username,blacklist)
+        );
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -34,7 +34,10 @@ public class UserController {
     }
     @PatchMapping("/logout")
     public ResponseEntity logout(HttpServletRequest request) {
-        String encryptedRefreshToken = jwtUtil.resolveRefreshToken(request);
-        String accessToken = jwtUtil.resolveAccessToken(request);
+        String encryptedRefreshToken = jwtUtil.getRefreshToken(request);
+        String accessToken = jwtUtil.getAccessToken(request);
+        userService.logout(encryptedRefreshToken, accessToken);
+
+        return new ResponseEntity<>(new SingleResponseDto<>("Logged out successfully"), HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -1,13 +1,18 @@
 package com.cona.KUsukKusuk.user.controller;
 
 import com.cona.KUsukKusuk.global.response.HttpResponse;
+import com.cona.KUsukKusuk.global.security.JWTUtil;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.dto.UserJoinResponse;
 import com.cona.KUsukKusuk.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class UserController {
     private final UserService userService;
+    private final JWTUtil jwtUtil;
 
     @PostMapping("/join")
     public HttpResponse<UserJoinResponse> join(@Valid @RequestBody UserJoinRequest userJoinRequest) {
@@ -25,5 +31,10 @@ public class UserController {
         return HttpResponse.okBuild(
                 UserJoinResponse.of(savedUser)
         );
+    }
+    @PatchMapping("/logout")
+    public ResponseEntity logout(HttpServletRequest request) {
+        String encryptedRefreshToken = jwtUtil.resolveRefreshToken(request);
+        String accessToken = jwtUtil.resolveAccessToken(request);
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserLogoutResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserLogoutResponse.java
@@ -8,7 +8,8 @@ public record UserLogoutResponse(String message,String blacklist) {
     public static UserLogoutResponse from(String username,String blacklist){
 
         return UserLogoutResponse.builder()
-                .message("요청하신" + username + "의 리프레시토큰이 블랙리스트 처리되었습니다.")
+                .message("요청하신 " + username + " 의 리프레시토큰이 블랙리스트 처리되었습니다."
+                        + " 새롭게 로그인후 RT,AT를 발급받아주세요")
                 .blacklist(blacklist)
                 .build();
     }

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserLogoutResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserLogoutResponse.java
@@ -1,0 +1,15 @@
+package com.cona.KUsukKusuk.user.dto;
+
+import lombok.Builder;
+
+@Builder
+public record UserLogoutResponse(String message,String blacklist) {
+
+    public UserLogoutResponse from(String username,String blacklist){
+
+        return UserLogoutResponse.builder()
+                .message("요청하신" + username + "의 리프레시토큰이 블랙리스트 처리되었습니다.")
+                .blacklist(blacklist)
+                .build();
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/UserLogoutResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/UserLogoutResponse.java
@@ -5,7 +5,7 @@ import lombok.Builder;
 @Builder
 public record UserLogoutResponse(String message,String blacklist) {
 
-    public UserLogoutResponse from(String username,String blacklist){
+    public static UserLogoutResponse from(String username,String blacklist){
 
         return UserLogoutResponse.builder()
                 .message("요청하신" + username + "의 리프레시토큰이 블랙리스트 처리되었습니다.")

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -48,10 +48,10 @@ public class UserService {
     }
 
     private String addToBlacklist(String encryptedRefreshToken) {
-        String blacklistKey = "refreshTokenBlacklist:" + encryptedRefreshToken;
+        String blacklistKey = encryptedRefreshToken;
 
         redisService.setValues(blacklistKey,"blacklist");
-        return "blaklist"+redisService.getValues(blacklistKey);
+        return "blaklist "+blacklistKey;
     }
 
 

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -2,12 +2,16 @@ package com.cona.KUsukKusuk.user.service;
 
 import com.cona.KUsukKusuk.global.exception.HttpExceptionCode;
 import com.cona.KUsukKusuk.global.exception.custom.security.SecurityJwtNotFoundException;
+import com.cona.KUsukKusuk.global.security.JWTUtil;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
 import io.jsonwebtoken.Claims;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +20,9 @@ import org.springframework.stereotype.Service;
 public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final JWTUtil jwtUtil;
 
     public User save(UserJoinRequest userJoinRequest) {
         User user = userJoinRequest.toEntity();
@@ -28,6 +35,8 @@ public class UserService {
     public void logout(String encryptedRefreshToken, String accessToken) {
         this.verifiedRefreshToken(encryptedRefreshToken);
 
+        addToBlacklist(encryptedRefreshToken);
+
     }
 
     private void verifiedRefreshToken(String encryptedRefreshToken) {
@@ -36,6 +45,12 @@ public class UserService {
         }
     }
 
+    private void addToBlacklist(String encryptedRefreshToken) {
+        String blacklistKey = "refreshTokenBlacklist:" + encryptedRefreshToken;
+
+        redisTemplate.opsForValue().set(blacklistKey, "blacklisted");
+        return redisTemplate.opsForValue().g
+    }
 
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.cona.KUsukKusuk.user.service;
 
 import com.cona.KUsukKusuk.global.exception.HttpExceptionCode;
 import com.cona.KUsukKusuk.global.exception.custom.security.SecurityJwtNotFoundException;
+import com.cona.KUsukKusuk.global.redis.RedisService;
 import com.cona.KUsukKusuk.global.security.JWTUtil;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
@@ -21,7 +22,7 @@ public class UserService {
     private final UserRepository userRepository;
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final RedisService redisService;
     private final JWTUtil jwtUtil;
 
     public User save(UserJoinRequest userJoinRequest) {
@@ -32,10 +33,11 @@ public class UserService {
         return savedUser;
     }
 
-    public void logout(String encryptedRefreshToken, String accessToken) {
+    public String logout(String encryptedRefreshToken, String accessToken) {
         this.verifiedRefreshToken(encryptedRefreshToken);
 
-        addToBlacklist(encryptedRefreshToken);
+        String result = addToBlacklist(encryptedRefreshToken);
+        return result;
 
     }
 
@@ -45,11 +47,11 @@ public class UserService {
         }
     }
 
-    private void addToBlacklist(String encryptedRefreshToken) {
+    private String addToBlacklist(String encryptedRefreshToken) {
         String blacklistKey = "refreshTokenBlacklist:" + encryptedRefreshToken;
 
-        redisTemplate.opsForValue().set(blacklistKey, "blacklisted");
-        return redisTemplate.opsForValue().g
+        redisService.setValues(blacklistKey,"blacklist");
+        return "blaklist"+redisService.getValues(blacklistKey);
     }
 
 

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -1,8 +1,12 @@
 package com.cona.KUsukKusuk.user.service;
 
+import com.cona.KUsukKusuk.global.exception.HttpExceptionCode;
+import com.cona.KUsukKusuk.global.exception.custom.security.SecurityJwtNotFoundException;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -20,5 +24,18 @@ public class UserService {
 
         return savedUser;
     }
+
+    public void logout(String encryptedRefreshToken, String accessToken) {
+        this.verifiedRefreshToken(encryptedRefreshToken);
+
+    }
+
+    private void verifiedRefreshToken(String encryptedRefreshToken) {
+        if (encryptedRefreshToken == null) {
+            throw new SecurityJwtNotFoundException(HttpExceptionCode.JWT_NOT_FOUND);
+        }
+    }
+
+
 
 }


### PR DESCRIPTION
### 요약 
로그아웃 과정시 서버측에서 제어하고 있는 리프레시토큰을 `Redis`로 **블랙리스트** 처리하는 기능을 구현하였습니다.

### 상세
우선적으로 클라이언트에서 로그아웃 실행시, 들고있던 RT,AT 모두 폐기하고 RT 를 서버로 블랙리스트 요청하는 시나리오로 구성해 보았습니다. 이렇게 한 이유는, RT는 상대적으로 기간이 길어 **서버측에서 제어 가능**해야 하는데, 지난 PR에서 레디스로 저장 가능하도록 하였습니다. 그래서, 기존에 보유하고 있는 RT를 삭제->블랙리스트 처리한 다음, 추후 RT를 이용한 AT 재발금 API에서 블랙리스트된 RT 인지 대조하는 작업이 가능하도록 구현하였습니다. 이로인해, 중간에 RT가 탈취당하더라도, 로그아웃을 한다면, 해커가 더이상 RT를 사용하지 못하도록 **보안을강화** 하였습니다. 

### 추가 수정사항
기존 순수 `RedisTemplate`을 사용한 방식을 하나의 책임을 가진 `RedisService` 를 구현하여 스프링으로 마이그레이션 하였습니다. 이로서 개발 편의성을 높였습니다.
