### PR TITLE
💡 [Feat] : 장소 페이지네이션 기능 구현

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/bookmark/service/BookmarkService.java
+++ b/src/main/java/com/cona/KUsukKusuk/bookmark/service/BookmarkService.java
@@ -12,6 +12,7 @@ import com.cona.KUsukKusuk.spot.repository.SpotRepository;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.service.UserService;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,6 +30,11 @@ public class BookmarkService {
 
         Spot spot = spotRepository.findById(spotId)
                 .orElseThrow(() -> new SpotNotFoundException(HttpExceptionCode.SPOT_NOT_FOUND));
+        Optional<Bookmark> existbookmark = bookmarkRepository.findByUserAndSpot(user, spot);
+
+        if (existbookmark.isPresent()) {
+            return;
+        }
 
         Bookmark bookmark = new Bookmark();
         bookmark.setUser(user);

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentJoinResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentJoinResponse.java
@@ -8,14 +8,14 @@ import lombok.Builder;
 
 @Builder
 public record CommentJoinResponse (
-        Long id, User user, Spot spot, String comment
+        Long commentId, String nickname, Long spotId, String comment
 )
 {
     public static CommentJoinResponse of(Comment comment){
         return CommentJoinResponse.builder()
-                .id(comment.getId())
-                .user(comment.getUser())
-                .spot(comment.getSpot())
+                .commentId(comment.getId())
+                .nickname(comment.getUser().getNickname())
+                .spotId(comment.getSpot().getId())
                 .comment(comment.getComment())
                 .build();
     }

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentUpdateResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentUpdateResponse.java
@@ -8,14 +8,14 @@ import lombok.Builder;
 
 @Builder
 public record CommentUpdateResponse (
-        Long id, User user, Spot spot, String comment
+        Long commentId, String nickname, Long spotId, String comment
 
 ){
     public static CommentUpdateResponse of(Comment comment){
         return CommentUpdateResponse.builder()
-                .id(comment.getId())
-                .user(comment.getUser())
-                .spot(comment.getSpot())
+                .commentId(comment.getId())
+                .nickname(comment.getUser().getNickname())
+                .spotId(comment.getSpot().getId())
                 .comment(comment.getComment())
                 .build();
     }

--- a/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
@@ -59,7 +59,7 @@ public class CommentService {
         }
 
         //commentUserName과 comment의 작성자 일치 확인
-        if (wantToUpdate.getUser().getNickname().equals(commentUserName))
+        if (wantToUpdate.getUser().getUserId().equals(commentUserName))
             return wantToUpdate;
         else
             throw new CommentUserNotMatchedException("Don't have authority to update the comment.");

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -83,7 +83,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String password = customUserDetails.getPassword();
         //AT : 6분
-        String accessToken = jwtUtil.createJwt(username, password, 60*60*1000L);
+        String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
         //RT : 7일
         String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
 

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -83,7 +83,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String password = customUserDetails.getPassword();
         //AT : 6분
-        String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
+        String accessToken = jwtUtil.createJwt(username, password, 60*60*1000L);
         //RT : 7일
         String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
 

--- a/src/main/java/com/cona/KUsukKusuk/like/service/LikeService.java
+++ b/src/main/java/com/cona/KUsukKusuk/like/service/LikeService.java
@@ -15,6 +15,7 @@ import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
 import com.cona.KUsukKusuk.user.service.UserService;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,11 @@ public class LikeService {
 
         Spot spot = spotRepository.findById(likeDto.spotId())
                 .orElseThrow(() -> new SpotNotFoundException(HttpExceptionCode.SPOT_NOT_FOUND));
+
+        Optional<UserLike> existlike = userLikeRepository.findByUserAndSpot(user, spot);
+        if (existlike.isPresent()) {
+            return;
+        }
 
         UserLike userLike = new UserLike();
         userLike.setUser(user);

--- a/src/main/java/com/cona/KUsukKusuk/spot/controller/SpotController.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/controller/SpotController.java
@@ -2,6 +2,7 @@ package com.cona.KUsukKusuk.spot.controller;
 
 import com.cona.KUsukKusuk.global.response.HttpResponse;
 import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.spot.dto.CommentResponse;
 import com.cona.KUsukKusuk.spot.dto.SpotDeleteResponse;
 import com.cona.KUsukKusuk.spot.dto.SpotDetailResponse;
 import com.cona.KUsukKusuk.spot.dto.SpotGetResponse;
@@ -84,6 +85,18 @@ public class SpotController {
                 SpotDeleteResponse.of("장소삭제가 성공적으로 이루어졌습니다.")
         );
     }
+    @GetMapping("/{spotId}/comments")
+    @Operation(summary = "장소 댓글 조회", description = "특정 장소에 등록된 댓글을 조회합니다.")
+    public HttpResponse<List<CommentResponse>> getSpotComments(@PathVariable Long spotId) {
+        List<CommentResponse> comments = spotService.getSpotComments(spotId);
+        return HttpResponse.okBuild(comments);
+    }
+
+
+
+
+
+
 
 }
 

--- a/src/main/java/com/cona/KUsukKusuk/spot/dto/CommentResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/dto/CommentResponse.java
@@ -1,0 +1,18 @@
+package com.cona.KUsukKusuk.spot.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommentResponse {
+    private Long commentId;
+    private String content;
+    private String author;
+    boolean deletable;
+    private LocalDateTime createdDate;
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotDetailResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotDetailResponse.java
@@ -15,6 +15,7 @@ public record SpotDetailResponse(Long spotId,
                                  Boolean bookmark,
                                  Boolean like,
 
+
                                  String review) {
 
     public static SpotDetailResponse fromSpot(Spot spot,Boolean isBookmark, Boolean isLike) {

--- a/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/controller/UserController.java
@@ -132,14 +132,24 @@ public class UserController {
         return HttpResponse.okBuild(userProfile);
     }
 
-    @GetMapping("/likes-bookmarks")
-    @Operation(summary = "사용자 좋아요/북마크 조회", description = "로그인한 사용자의 등록한 좋아요/북마크 조회를 수행합니다.")
 
-    public HttpResponse<Page<BoomarkLikeResponseDto>> getUserBookmarksandLikes(@RequestParam(defaultValue = "5") int page,
-                                                                               @RequestParam(defaultValue = "5") int size) {
-        Page<BoomarkLikeResponseDto> bookmarkAndLikes = userService.getBookmarkAndLikes(page, size);
+
+
+
+    @GetMapping("/likes-bookmarks1")
+    @Operation(summary = "사용자 좋아요/북마크 조회", description = "로그인한 사용자의 등록한 좋아요/북마크 조회를 수행합니다.")
+    public HttpResponse<List<BoomarkLikeResponseDto>> getUserBookmarksandLikes1(
+            @RequestParam(defaultValue = "1") int pageNumber,
+            @RequestParam(defaultValue = "10") int pageSize) {
+
+        int adjustedPageNumber = pageNumber - 1;
+
+
+        List<BoomarkLikeResponseDto> bookmarkAndLikes = userService.getBookmarkandLikes(adjustedPageNumber, pageSize);
+
         return HttpResponse.okBuild(bookmarkAndLikes);
     }
+
 
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/BoomarkLikeResponseDto.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/BoomarkLikeResponseDto.java
@@ -16,9 +16,13 @@ public record BoomarkLikeResponseDto(
 
         Boolean bookmark,
         Boolean like,
-        String spotImageurl
+        String spotImageurl,
+        long totalElements,
+        int page,
+        int size,
+        int totalPages
 ) {
-    public static BoomarkLikeResponseDto of(Spot spot, Boolean isBookmark, Boolean isLike) {
+    public static BoomarkLikeResponseDto of(Spot spot, Boolean isBookmark, Boolean isLike, PageInfo pageInfo) {
         return BoomarkLikeResponseDto.builder()
                 .spotName(spot.getSpotName())
                 .spotImageurl(spot.getImageUrls().get(0))
@@ -26,6 +30,10 @@ public record BoomarkLikeResponseDto(
                 .author(spot.getUser().getNickname())
                 .bookmark(isBookmark)
                 .like(isLike)
+                .totalElements(pageInfo.getTotalElements())
+                .page(pageInfo.getPage())
+                .size(pageInfo.getSize())
+                .totalPages(pageInfo.getTotalPages())
                 .build();
     }
 }


### PR DESCRIPTION
## 요약
- 기존 페이지네이션 시 page 의 범위가 전체 리스트의 범위를 넘어가버리는 경우에 에러가 나왔지만, 해당 로직을 추가하여 빈 리스트를 반환하도록 수정하였습니다.
- 또한 장소 - 댓글 조회 기능 구현하였고, 삭제 가능 여부를 boolean 값으로 추가하였습니다.
- 댓글 삭제시 유효성 검증이 실패햐여 오류 분석 결과 `닉네임` 비교가 아니라 `아이디` 비교로 수정하였습니다. 