### PR TITLE
[feat]: comment 전체 조회

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
@@ -79,15 +79,15 @@ public class CommentController {
 
     @GetMapping("/myAllComments")
     @Operation(summary = "자신의 댓글 전체 조회", description = "로그인한 사용자의 댓글을 전체 조회합니다.")
-    public HttpResponse<List<CommentGetResponse>> allComments(){
+    public HttpResponse<List<CommentPaginationResponse>> allComments(){
         User user = commentService.getCurrentUser();
         Long userId = user.getId(); //userId 정보
         //List<SpotGetResponse> allSpots = spotService.getAllSpots(); //모든 spot 정보
         List<CommentGetResponse> commentsByUser = commentService.getUserCommentsOfAllSpots(userId); //사용자가 쓴 comment만
         //페이지 네이션 적용
-
+        List<CommentPaginationResponse> commentPaginationResponses = commentService.getPagedComments(commentsByUser);
         return  HttpResponse.okBuild(
-                commentsByUser);
+                commentPaginationResponses);
     }
 
 

--- a/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
@@ -7,10 +7,14 @@ import com.cona.KUsukKusuk.comment.exception.CommentUserNotMatchedException;
 import com.cona.KUsukKusuk.comment.service.CommentService;
 import com.cona.KUsukKusuk.global.response.HttpResponse;
 import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.spot.dto.SpotGetResponse;
+import com.cona.KUsukKusuk.spot.service.SpotService;
 import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 
 @RestController
@@ -18,11 +22,13 @@ import org.springframework.web.bind.annotation.*;
 public class CommentController {
     final private CommentService commentService;
     final private UserService userService;
+    final private SpotService spotService;
     private CommentJoinRequest CommentJoinRequest;
 
-    public CommentController(CommentService commentService, UserService userService) {
+    public CommentController(CommentService commentService, UserService userService, SpotService spotService) {
         this.commentService = commentService;
         this.userService = userService;
+        this.spotService = spotService;
     }
 
     @PostMapping("/{spotId}/register")
@@ -32,9 +38,9 @@ public class CommentController {
         User user = commentService.getCurrentUser();
         Spot spot = commentService.getCurrentSpot(spotId);
         //위 user, spot 사용해서 comment 객체 만들기
-        System.out.println("user, spot 까지 담기 완료");
+        //System.out.println("user, spot 까지 담기 완료");
         Comment comment = commentJoinRequest.toEntity(user, spot);
-        System.out.println("comment 객체 생성 완료");
+        //System.out.println("comment 객체 생성 완료");
         Comment savedComment = commentService.save(comment);
         return  HttpResponse.okBuild(
                 CommentJoinResponse.of(savedComment));
@@ -69,6 +75,19 @@ public class CommentController {
         return HttpResponse.okBuild(
                 CommentDeleteResponse.of("댓글이 삭제 되었습니다.")
         );
+    }
+
+    @GetMapping("/myAllComments")
+    @Operation(summary = "자신의 댓글 전체 조회", description = "로그인한 사용자의 댓글을 전체 조회합니다.")
+    public HttpResponse<List<CommentGetResponse>> allComments(){
+        User user = commentService.getCurrentUser();
+        Long userId = user.getId(); //userId 정보
+        //List<SpotGetResponse> allSpots = spotService.getAllSpots(); //모든 spot 정보
+        List<CommentGetResponse> commentsByUser = commentService.getUserCommentsOfAllSpots(userId); //사용자가 쓴 comment만
+        //페이지 네이션 적용
+
+        return  HttpResponse.okBuild(
+                commentsByUser);
     }
 
 

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentGetResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentGetResponse.java
@@ -1,0 +1,24 @@
+package com.cona.KUsukKusuk.comment.dto;
+
+import com.cona.KUsukKusuk.comment.domain.Comment;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record CommentGetResponse (
+        Long commentNum , Long spotId, Long commentId, String comment, LocalDateTime createDate, Long userId
+
+){
+    public static CommentGetResponse of(Long commentNum, Comment comment,LocalDateTime createDate)
+    {
+        return CommentGetResponse.builder()
+                .commentNum(commentNum)
+                .spotId(comment.getSpot().getId())
+                .commentId(comment.getId())
+                .comment(comment.getComment())
+                .userId(comment.getUser().getId())
+                .createDate(createDate)
+                .build();
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentPaginationResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentPaginationResponse.java
@@ -1,0 +1,28 @@
+package com.cona.KUsukKusuk.comment.dto;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record CommentPaginationResponse (
+        /*
+        totalComments : 댓글 전체 개수
+        curPageNum : 현재 페이지 번호
+        lastPage : 마지막 페이지 번호
+        amountInBlock : 한 페이지당 보여지는 댓글 개수
+         */
+        Long totalComments, Long curPageNum, Long lastPage, Long amountInBlock, List<CommentGetResponse> list
+){
+    public static CommentPaginationResponse of(List<CommentGetResponse> commentsByUser,Long totalComments, Long curPageNum, Long lastPage, Long amountInBlock)
+    {
+
+        return CommentPaginationResponse.builder()
+                .totalComments(totalComments)
+                .curPageNum(curPageNum)
+                .lastPage(lastPage)
+                .amountInBlock(amountInBlock)
+                .list(commentsByUser)
+                .build();
+    }
+}

--- a/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
@@ -1,10 +1,12 @@
 package com.cona.KUsukKusuk.comment.service;
 
 import com.cona.KUsukKusuk.comment.domain.Comment;
+import com.cona.KUsukKusuk.comment.dto.CommentGetResponse;
 import com.cona.KUsukKusuk.comment.exception.CommentNotFoundException;
 import com.cona.KUsukKusuk.comment.exception.CommentUserNotMatchedException;
 import com.cona.KUsukKusuk.comment.repository.CommentRepository;
 import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.spot.dto.SpotGetResponse;
 import com.cona.KUsukKusuk.spot.exception.SpotNotFoundException;
 import com.cona.KUsukKusuk.spot.repository.SpotRepository;
 import com.cona.KUsukKusuk.user.domain.User;
@@ -13,6 +15,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.NonNull;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -68,5 +71,21 @@ public class CommentService {
 
     public void delete(Comment comment) {
         commentRepository.delete(comment);
+    }
+
+
+    public List<CommentGetResponse> getUserCommentsOfAllSpots(Long userId) {
+        //목표 : 사용자가 쓴 comment만 list<CommentGetResponse> 형태로 반환
+        List<Comment> comments = commentRepository.findAll();
+        List<CommentGetResponse> commentsByuser = new ArrayList<>();
+        Long cNum = 0L;
+        for (Comment c : comments)
+        {
+            if (c.getUser().getId().equals(userId))
+                commentsByuser.add(CommentGetResponse.of(++cNum,c,c.getCreatedDate()));
+        }
+
+        return commentsByuser;
+
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package com.cona.KUsukKusuk.comment.service;
 
 import com.cona.KUsukKusuk.comment.domain.Comment;
 import com.cona.KUsukKusuk.comment.dto.CommentGetResponse;
+import com.cona.KUsukKusuk.comment.dto.CommentPaginationResponse;
 import com.cona.KUsukKusuk.comment.exception.CommentNotFoundException;
 import com.cona.KUsukKusuk.comment.exception.CommentUserNotMatchedException;
 import com.cona.KUsukKusuk.comment.repository.CommentRepository;
@@ -87,5 +88,28 @@ public class CommentService {
 
         return commentsByuser;
 
+    }
+
+    public List<CommentPaginationResponse> getPagedComments(List<CommentGetResponse> commentsByUser) {
+        //commentsByuser 한 객체마다 pagination 해줘서 pagedComments 에 넣어주기
+        List<CommentPaginationResponse> pagedComments = new ArrayList<>();
+
+        Long totalComments = (long) commentsByUser.size();
+        Long amountInBlock = 10L;
+        Long lastPage = totalComments / amountInBlock; // 전체 페이지 수
+        // 나머지가 0보다 큰 경우에는 몫에 1을 더해주기
+        if (totalComments % amountInBlock > 0) {
+            lastPage++;
+        }
+
+        Long curPageNum = 1L;
+
+        for (int i = 0; i < totalComments; i += amountInBlock) {
+            int endIndex = (int) Math.min(i + amountInBlock, commentsByUser.size());
+            List<CommentGetResponse> currentPageComments = commentsByUser.subList(i, endIndex);
+            pagedComments.add(CommentPaginationResponse.of(currentPageComments, totalComments, curPageNum, lastPage, (long) (endIndex-i)));
+            curPageNum++;
+        }
+        return pagedComments;
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/spot/controller/SpotController.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/controller/SpotController.java
@@ -11,11 +11,10 @@ import com.cona.KUsukKusuk.spot.dto.SpotUpdateRequest;
 import com.cona.KUsukKusuk.spot.dto.SpotUploadRequest;
 import com.cona.KUsukKusuk.spot.dto.SpotJoinResponse;
 import com.cona.KUsukKusuk.spot.service.SpotService;
-import com.cona.KUsukKusuk.user.domain.User;
 import com.cona.KUsukKusuk.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
+
 import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
@@ -4,7 +4,6 @@ import com.cona.KUsukKusuk.bookmark.domain.Bookmark;
 import com.cona.KUsukKusuk.bookmark.repository.BookmarkRepository;
 import com.cona.KUsukKusuk.comment.domain.Comment;
 import com.cona.KUsukKusuk.global.exception.HttpExceptionCode;
-import com.cona.KUsukKusuk.global.response.HttpResponse;
 import com.cona.KUsukKusuk.global.s3.S3Service;
 import com.cona.KUsukKusuk.like.UserLike;
 import com.cona.KUsukKusuk.like.repository.UserLikeRepository;
@@ -12,28 +11,22 @@ import com.cona.KUsukKusuk.spot.domain.Spot;
 import com.cona.KUsukKusuk.spot.dto.CommentResponse;
 import com.cona.KUsukKusuk.spot.dto.SpotDetailResponse;
 import com.cona.KUsukKusuk.spot.dto.SpotGetResponse;
-import com.cona.KUsukKusuk.spot.dto.SpotJoinResponse;
 import com.cona.KUsukKusuk.spot.dto.SpotUpdateRequest;
 import com.cona.KUsukKusuk.spot.dto.SpotUploadRequest;
 import com.cona.KUsukKusuk.spot.exception.SpotNotFoundException;
 import com.cona.KUsukKusuk.spot.repository.SpotRepository;
 import com.cona.KUsukKusuk.user.domain.User;
-import com.cona.KUsukKusuk.user.dto.UserJoinRequest;
 import com.cona.KUsukKusuk.user.exception.UserNotFoundException;
 import com.cona.KUsukKusuk.user.repository.UserRepository;
 import com.cona.KUsukKusuk.user.service.UserService;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.validation.Valid;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Primary;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.multipart.MultipartFile;
 
 @Service


### PR DESCRIPTION
- 로그인한 사용자가 작성했던 전체 댓글 (모든 장소들에 대한 댓글) 을 /myAllComments getmapping으로 구현했습니다.

- 또한 댓글 페이지네이션은 CommentPaginationResponse 클래스를 새로 추가하여 
      totalComments : 댓글 전체 개수
      curPageNum : 현재 페이지 번호
      lastPage : 마지막 페이지 번호
      amountInBlock : 한 페이지당 보여지는 댓글 개수
      list : 해당 페이지에 들어간 댓글 정보들
위 정보들을 response로 받을 수 있게끔 구현했습니다.
![image](https://github.com/KONKUK-MAP-Service/Ku-suk-Ku-suk/assets/108603070/1a6ef678-7ae8-498d-a302-9330ac043784)
