### PR TITLE
✔️ [Fix] :  장소 외래키 제약조건 오류 수정 

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/comment/domain/Comment.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/domain/Comment.java
@@ -36,4 +36,5 @@ public class Comment extends BaseEntity {
     @Column(nullable = false)
     private String comment;
 
+
 }

--- a/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/security/LoginFilter.java
@@ -83,7 +83,7 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         String password = customUserDetails.getPassword();
         //AT : 6분
-        String accessToken = jwtUtil.createJwt(username, password, 60*60*100L);
+        String accessToken = jwtUtil.createJwt(username, password, 60*60*1000L);
         //RT : 7일
         String refreshToken = jwtUtil.createRefreshToken(username, password, 86400000*7L);
 

--- a/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/domain/Spot.java
@@ -6,6 +6,7 @@ import com.cona.KUsukKusuk.global.domain.BaseEntity;
 import com.cona.KUsukKusuk.like.UserLike;
 import com.cona.KUsukKusuk.picture.Picture;
 import com.cona.KUsukKusuk.user.domain.User;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
@@ -36,16 +37,16 @@ public class Spot extends BaseEntity {
     @JoinColumn(name = "user_id")
     private User user;
 
-    @OneToMany(mappedBy = "spot")
+    @OneToMany(mappedBy = "spot", cascade = CascadeType.REMOVE)
     private List<UserLike> userLikes = new ArrayList<>();
 
     @OneToMany(mappedBy = "spot")
     private List<Picture> pictures = new ArrayList<>();
 
-    @OneToMany(mappedBy = "spot")
+    @OneToMany(mappedBy = "spot",cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "spot")
+    @OneToMany(mappedBy = "spot", cascade = CascadeType.REMOVE)
     private List<Bookmark> bookmarks = new ArrayList<>();
     @Column(nullable = false)
     private String spotName;

--- a/src/main/java/com/cona/KUsukKusuk/user/dto/BoomarkLikeResponseDto.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/dto/BoomarkLikeResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 public record BoomarkLikeResponseDto(
 
         String spotName,
+        Long spotId,
         String review,
         LocalDateTime createDate,
 
@@ -26,6 +27,8 @@ public record BoomarkLikeResponseDto(
         return BoomarkLikeResponseDto.builder()
                 .spotName(spot.getSpotName())
                 .spotImageurl(spot.getImageUrls().get(0))
+                .createDate(spot.getCreatedDate())
+                .spotId(spot.getId())
                 .review(spot.getReview())
                 .author(spot.getUser().getNickname())
                 .bookmark(isBookmark)

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -44,6 +45,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserService {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
@@ -136,12 +138,13 @@ public class UserService {
         User member=userRepository.findByUserId(userId)
                 .orElseThrow(() -> new UserNotFoundException(HttpExceptionCode.USERID_NOT_FOUND));
 
-        if (member.getEmail() != email) {
+        if (!member.getEmail().equals(email)) {
             throw new UserNotFoundException(HttpExceptionCode.EMAIL_USER_NOT_EQUAL);
         }
 
         String newPassword = generateNewPassword();
         member.setPassword(bCryptPasswordEncoder.encode(newPassword));
+        member.setNoCryptpassword(newPassword);
         userRepository.save(member);
 
         String title = "쿠석쿠석 임시 비밀번호 발급";

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,8 +41,8 @@ spring:
       password : ${redis_password}
   servlet:
     multipart:
-      maxFileSize: 10MB
-      maxRequestSize: 30MB
+      maxFileSize: 30MB
+      maxRequestSize: 60MB
 
 decorator:
   datasource:


### PR DESCRIPTION
## 요약 
클라이언트분의 요청에서 장소 삭제시 해당 장소에 북마크나 좋아요, 댓글이 있는 경우 삭제가 되지 않는 오류를 해결하였습니다. ! 

## 상세
- 우선 외래키 제약조건에서 Cascade 옵션을 추가하여서 부모 엔티티 삭제시 자식 엔티티도 삭제가 이루어지도록 구현하였습니다. ! 해당 방법이 우리 서비스의 비즈니스 로직에도 적절한 것 같아서 그렇게 구현 하였습니다 !! ㅎㅎ 😄 