### PR TITLE
✔️ [Fix] : 장소, 댓글 도메인 클라이언트 반환값 수정

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
@@ -79,9 +79,13 @@ public class CommentController {
     @GetMapping("/myAllComments")
     @Operation(summary = "자신의 댓글 전체 조회", description = "로그인한 사용자의 댓글을 전체 조회합니다.('페이지 위치:보여지는 댓글 수'형식으로 입력받습니다.)")
     public HttpResponse<List<CommentListResponseDto>> allComments(@RequestParam(defaultValue = "1") int pageNumber,
+
                                                                @RequestParam(defaultValue = "10") int pageSize){
 
-        List<CommentListResponseDto> pagedComments = commentService.getPagedComments(pageNumber, pageSize);
+        int adjustedPageNumber = pageNumber - 1;
+
+
+        List<CommentListResponseDto> pagedComments = commentService.getPagedComments(adjustedPageNumber, pageSize);
         return  HttpResponse.okBuild(
                 pagedComments);
     }

--- a/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/controller/CommentController.java
@@ -76,17 +76,14 @@ public class CommentController {
         );
     }
 
-    @GetMapping("/myAllComments/{pageNum}/{commentsInPage}")
+    @GetMapping("/myAllComments")
     @Operation(summary = "자신의 댓글 전체 조회", description = "로그인한 사용자의 댓글을 전체 조회합니다.('페이지 위치:보여지는 댓글 수'형식으로 입력받습니다.)")
-    public HttpResponse<CommentPaginationResponse> allComments(@PathVariable("pageNum")Long pageNum, @PathVariable("commentsInPage")Long commentsInPage){
-        User user = commentService.getCurrentUser();
-        Long userId = user.getId(); //userId 정보
-        //List<SpotGetResponse> allSpots = spotService.getAllSpots(); //모든 spot 정보
-        List<CommentGetResponse> commentsByUser = commentService.getUserCommentsOfAllSpots(userId); //사용자가 쓴 comment만
-        //페이지 네이션 적용
-        CommentPaginationResponse commentPaginationResponses = commentService.getPagedComments(commentsByUser,pageNum, commentsInPage);
+    public HttpResponse<List<CommentListResponseDto>> allComments(@RequestParam(defaultValue = "1") int pageNumber,
+                                                               @RequestParam(defaultValue = "10") int pageSize){
+
+        List<CommentListResponseDto> pagedComments = commentService.getPagedComments(pageNumber, pageSize);
         return  HttpResponse.okBuild(
-                commentPaginationResponses);
+                pagedComments);
     }
 
 

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentGetResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentGetResponse.java
@@ -18,6 +18,7 @@ public record CommentGetResponse (
                 .commentId(comment.getId())
                 .comment(comment.getComment())
                 .userId(comment.getUser().getId())
+
                 .createDate(createDate)
                 .build();
     }

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentListResponseDto.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentListResponseDto.java
@@ -11,8 +11,9 @@ import lombok.Builder;
 public record CommentListResponseDto(
         String spotName,
         Long spotId,
+        String usersComment,
         String review,
-        LocalDateTime createDate,
+        LocalDateTime CommentcreateDate,
 
         String author,
 
@@ -28,11 +29,11 @@ public record CommentListResponseDto(
         return CommentListResponseDto.builder()
                 .spotName(comment.getSpot().getSpotName())
                 .spotImageurl(comment.getSpot().getImageUrls().get(0))
-                .createDate(comment.getCreatedDate())
+                .CommentcreateDate(comment.getCreatedDate())
                 .spotId(comment.getId())
                 .review(comment.getSpot().getReview())
                 .author(comment.getUser().getNickname())
-
+                .usersComment(comment.getComment())
                 .totalElements(pageInfo.getTotalElements())
                 .page(pageInfo.getPage())
                 .size(pageInfo.getSize())

--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentListResponseDto.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentListResponseDto.java
@@ -1,0 +1,44 @@
+package com.cona.KUsukKusuk.comment.dto;
+
+import com.cona.KUsukKusuk.comment.domain.Comment;
+import com.cona.KUsukKusuk.spot.domain.Spot;
+import com.cona.KUsukKusuk.user.dto.BoomarkLikeResponseDto;
+import com.cona.KUsukKusuk.user.dto.PageInfo;
+import java.time.LocalDateTime;
+import lombok.Builder;
+
+@Builder
+public record CommentListResponseDto(
+        String spotName,
+        Long spotId,
+        String review,
+        LocalDateTime createDate,
+
+        String author,
+
+
+        String spotImageurl,
+        long totalElements,
+        int page,
+        int size,
+        int totalPages
+) {
+
+    public static CommentListResponseDto of (Comment comment, PageInfo pageInfo){
+        return CommentListResponseDto.builder()
+                .spotName(comment.getSpot().getSpotName())
+                .spotImageurl(comment.getSpot().getImageUrls().get(0))
+                .createDate(comment.getCreatedDate())
+                .spotId(comment.getId())
+                .review(comment.getSpot().getReview())
+                .author(comment.getUser().getNickname())
+
+                .totalElements(pageInfo.getTotalElements())
+                .page(pageInfo.getPage())
+                .size(pageInfo.getSize())
+                .totalPages(pageInfo.getTotalPages())
+                .build();
+    }
+
+
+}

--- a/src/main/java/com/cona/KUsukKusuk/comment/repository/CommentRepository.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/repository/CommentRepository.java
@@ -2,9 +2,13 @@ package com.cona.KUsukKusuk.comment.repository;
 
 import com.cona.KUsukKusuk.comment.domain.Comment;
 import com.cona.KUsukKusuk.user.domain.User;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     void deleteAllByUser(User user);
+
+    List<Comment> findByUser(User user);
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
@@ -2,6 +2,7 @@ package com.cona.KUsukKusuk.comment.service;
 
 import com.cona.KUsukKusuk.comment.domain.Comment;
 import com.cona.KUsukKusuk.comment.dto.CommentGetResponse;
+import com.cona.KUsukKusuk.comment.dto.CommentListResponseDto;
 import com.cona.KUsukKusuk.comment.dto.CommentPaginationResponse;
 import com.cona.KUsukKusuk.comment.exception.CommentNotFoundException;
 import com.cona.KUsukKusuk.comment.exception.CommentUserNotMatchedException;
@@ -10,7 +11,10 @@ import com.cona.KUsukKusuk.spot.domain.Spot;
 import com.cona.KUsukKusuk.spot.exception.SpotNotFoundException;
 import com.cona.KUsukKusuk.spot.repository.SpotRepository;
 import com.cona.KUsukKusuk.user.domain.User;
+import com.cona.KUsukKusuk.user.dto.BoomarkLikeResponseDto;
+import com.cona.KUsukKusuk.user.dto.PageInfo;
 import com.cona.KUsukKusuk.user.service.UserService;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -21,11 +25,13 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final SpotRepository spotRepository;
     private final UserService userService;
+
     public CommentService(CommentRepository commentRepository, SpotRepository spotRepository, UserService userService) {
         this.commentRepository = commentRepository;
         this.spotRepository = spotRepository;
         this.userService = userService;
     }
+
     public Comment save(Comment comment) {
         Comment savedComment = commentRepository.save(comment);
         return savedComment;
@@ -37,13 +43,14 @@ public class CommentService {
         return user;
     }
 
-    public  Spot getCurrentSpot(Long spotId) {
+    public Spot getCurrentSpot(Long spotId) {
         Spot spot = spotRepository.findById(spotId)
                 .orElseThrow(() -> new SpotNotFoundException());
         return spot;
     }
 
-    public Comment getCurrentComment(String commentUserName , Spot spot, Long commentId) throws CommentNotFoundException, CommentUserNotMatchedException {
+    public Comment getCurrentComment(String commentUserName, Spot spot, Long commentId)
+            throws CommentNotFoundException, CommentUserNotMatchedException {
         List<Comment> commentList = spot.getComments();
         Comment wantToUpdate = null; // 초기화를 null로 설정
         for (Comment comment : commentList) {
@@ -59,10 +66,11 @@ public class CommentService {
         }
 
         //commentUserName과 comment의 작성자 일치 확인
-        if (wantToUpdate.getUser().getUserId().equals(commentUserName))
+        if (wantToUpdate.getUser().getUserId().equals(commentUserName)) {
             return wantToUpdate;
-        else
+        } else {
             throw new CommentUserNotMatchedException("Don't have authority to update the comment.");
+        }
 
     }
 
@@ -71,46 +79,53 @@ public class CommentService {
     }
 
 
-    public List<CommentGetResponse> getUserCommentsOfAllSpots(Long userId) {
-        //목표 : 사용자가 쓴 comment만 list<CommentGetResponse> 형태로 반환
-        List<Comment> comments = commentRepository.findAll();
-        List<CommentGetResponse> commentsByuser = new ArrayList<>();
-        Long cNum = 0L;
-        for (Comment c : comments)
-        {
-            if (c.getUser().getId().equals(userId))
-                commentsByuser.add(CommentGetResponse.of(++cNum,c,c.getCreatedDate()));
+    public List<CommentListResponseDto> getUserCommentsOfAllSpots(Long userId) {
+        // 사용자가 쓴 comment만 가져오기
+        User user = getCurrentUser();
+        List<Comment> comments = commentRepository.findByUser(user);
+        List<CommentListResponseDto> commentsByUser = new ArrayList<>();
+
+        // 가져온 comment를 CommentListResponseDto로 변환하여 리스트에 추가
+        for (Comment comment : comments) {
+            CommentListResponseDto commentDto = CommentListResponseDto.builder()
+                    .spotName(comment.getSpot().getSpotName())
+                    .spotId(comment.getSpot().getId())
+                    .review(comment.getSpot().getReview())
+                    .createDate(comment.getSpot().getCreatedDate())
+                    .author(comment.getUser().getNickname())
+                    .spotImageurl(comment.getSpot().getImageUrls().get(0))
+                    .build();
+            commentsByUser.add(commentDto);
         }
 
-        return commentsByuser;
-
+        return commentsByUser;
     }
 
-    public CommentPaginationResponse getPagedComments(List<CommentGetResponse> commentsByUser, Long pageNum, Long commentsInPage){
-        //commentsByuser 한 객체마다 pagination 해줘서 pagedComments 에 넣어주기
-        List<CommentPaginationResponse> pagedComments = new ArrayList<>();
+    public List<CommentListResponseDto> getPagedComments( int
+            pageNumber
+            , int pageSize) {
 
-        Long totalComments = (long) commentsByUser.size();
-        Long amountInBlock = commentsInPage;
-        Long lastPage = totalComments / amountInBlock; // 전체 페이지 수
-        // 나머지가 0보다 큰 경우에는 몫에 1을 더해주기
-        if (totalComments % amountInBlock > 0) {
-            lastPage++;
+        User user = getCurrentUser();
+        List<Comment> comments = commentRepository.findByUser(user);
+        List<CommentListResponseDto> pagedResponse = new ArrayList<>();
+
+
+        int start = Math.min(pageNumber * pageSize, comments.size());
+        int end = Math.min((pageNumber + 1) * pageSize, comments.size());
+
+        if (start > end) {
+            start = end;
         }
-        if (pageNum > lastPage || pageNum <= 0) {//요청하는 페이지가 존재하지 않는 경우
-            return null;
-        }
+        PageInfo pageInfo = new PageInfo();
+        pageInfo.setTotalElements(comments.size());
+        pageInfo.setPage(pageNumber + 1);
+        pageInfo.setSize(pageSize);
+        pageInfo.setTotalPages((int) Math.ceil((double) comments.size() / pageSize));
 
-        Long curPageNum = 1L;
+        List<Comment> pagedcomments = comments.subList(start, end);
 
-        for (int i = 0; i < totalComments; i += amountInBlock) {
-            int endIndex = (int) Math.min(i + amountInBlock, commentsByUser.size());
-            List<CommentGetResponse> currentPageComments = commentsByUser.subList(i, endIndex);
-            pagedComments.add(CommentPaginationResponse.of(currentPageComments, totalComments, curPageNum, lastPage, (long) (endIndex-i)));
-            curPageNum++;
-        }
-
-
-        return pagedComments.get((int) (pageNum - 1));
+        return pagedcomments.stream()
+                .map(comment -> CommentListResponseDto.of(comment, pageInfo))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/service/CommentService.java
@@ -15,12 +15,14 @@ import com.cona.KUsukKusuk.user.dto.BoomarkLikeResponseDto;
 import com.cona.KUsukKusuk.user.dto.PageInfo;
 import com.cona.KUsukKusuk.user.service.UserService;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Service
+@Slf4j
 public class CommentService {
     private final CommentRepository commentRepository;
     private final SpotRepository spotRepository;
@@ -91,7 +93,7 @@ public class CommentService {
                     .spotName(comment.getSpot().getSpotName())
                     .spotId(comment.getSpot().getId())
                     .review(comment.getSpot().getReview())
-                    .createDate(comment.getSpot().getCreatedDate())
+                    .CommentcreateDate(comment.getSpot().getCreatedDate())
                     .author(comment.getUser().getNickname())
                     .spotImageurl(comment.getSpot().getImageUrls().get(0))
                     .build();
@@ -107,6 +109,7 @@ public class CommentService {
 
         User user = getCurrentUser();
         List<Comment> comments = commentRepository.findByUser(user);
+        System.out.println("comments.size() = " + comments.size());
         List<CommentListResponseDto> pagedResponse = new ArrayList<>();
 
 

--- a/src/main/java/com/cona/KUsukKusuk/global/domain/BaseEntity.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/domain/BaseEntity.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -16,8 +17,9 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(updatable = false)
-    public LocalDateTime createdDate = LocalDateTime.now().plusHours(9);
+    public LocalDateTime createdDate = LocalDateTime.now(ZoneId.of("Asia/Seoul")); // 한국 시간으로 생성 날짜 설정
 
     @LastModifiedDate
-    public LocalDateTime updatedDate = LocalDateTime.now().plusHours(9);
+    public LocalDateTime updatedDate = LocalDateTime.now(ZoneId.of("Asia/Seoul")); // 한국 시간으로 수정 날짜 설정
 }
+

--- a/src/main/java/com/cona/KUsukKusuk/global/s3/S3Service.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/s3/S3Service.java
@@ -129,7 +129,7 @@ public class S3Service {
 
 
     public void deleteSpotImages(Spot spot,User user) {
-        //현재 url에서 키 값을 추출해서 그대로 해당 키의 버킷 객체를
+        //현재 url에서 키 값을 추출해서 그대로 해당 키의 버킷 객체를 삭제(전부삭제)
 
         List<String> imageUrls = spot.getImageUrls();
         if(!imageUrls.isEmpty()){
@@ -139,6 +139,15 @@ public class S3Service {
                 amazonS3.deleteObject(bucket,key);
             }
 
+        }
+    }
+    public void deleteImagebyUrl(User member,String url) {
+
+
+
+        if (url != null) {
+            String key = extractString(url, member.getUserId());
+            amazonS3.deleteObject(bucket, key);
         }
     }
 

--- a/src/main/java/com/cona/KUsukKusuk/spot/dto/CommentResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/dto/CommentResponse.java
@@ -14,5 +14,6 @@ public class CommentResponse {
     private String author;
     boolean deletable;
     private LocalDateTime createdDate;
+    private String profileImage;
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotDetailResponse.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotDetailResponse.java
@@ -1,6 +1,7 @@
 package com.cona.KUsukKusuk.spot.dto;
 
 import com.cona.KUsukKusuk.spot.domain.Spot;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 
@@ -14,6 +15,7 @@ public record SpotDetailResponse(Long spotId,
                                  String author,
                                  Boolean bookmark,
                                  Boolean like,
+                                 LocalDateTime createDate,
 
 
                                  String review) {
@@ -29,6 +31,7 @@ public record SpotDetailResponse(Long spotId,
                 .review(spot.getReview())
                 .author(spot.getUser().getNickname())
                 .bookmark(isBookmark)
+                .createDate(spot.getCreatedDate())
                 .like(isLike)
                 .build();
     }

--- a/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotUpdateRequest.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotUpdateRequest.java
@@ -15,7 +15,9 @@ public record SpotUpdateRequest (
 
 
 
-     String review
+     String review,
+
+     int deleteImageindex
 ){
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
@@ -130,9 +130,20 @@ public class SpotService {
         if (!spot.getUser().equals(user)) {
             throw new UserNotFoundException(HttpExceptionCode.USER_NOT_MATCH);
         }
+        int deleteImageindex = spotUpdateRequest.deleteImageindex();
+
+
+        List<String> imageUrls = spot.getImageUrls();
+        if (deleteImageindex>=1 && deleteImageindex<=imageUrls.size()) {
+            String deleteimageurl = imageUrls.get(deleteImageindex+1);
+            imageUrls.remove(deleteImageindex+1);
+            //해당 인덱스에 대응하는 이미지 삭제후 다시 저장(영속).
+            spot.setImageUrls(imageUrls);
+            s3Service.deleteImagebyUrl(user,deleteimageurl);
+        }
 
         if (!images.get(0).isEmpty()) {
-            //이미지가 존재할 경우
+            //이미지가 존재할 경우 기존 이미지 전부 삭제후 새로운 이미지 업로드
             s3Service.deleteSpotImages(spot,user);
             List<String> imagesurl = s3Service.uploadImages(images, username);
             spot.setImageUrls(imagesurl);

--- a/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
@@ -134,9 +134,10 @@ public class SpotService {
 
 
         List<String> imageUrls = spot.getImageUrls();
+
         if (deleteImageindex>=1 && deleteImageindex<=imageUrls.size()) {
-            String deleteimageurl = imageUrls.get(deleteImageindex+1);
-            imageUrls.remove(deleteImageindex+1);
+            String deleteimageurl = imageUrls.get(deleteImageindex-1);
+            imageUrls.remove(deleteImageindex-1);
             //해당 인덱스에 대응하는 이미지 삭제후 다시 저장(영속).
             spot.setImageUrls(imageUrls);
             s3Service.deleteImagebyUrl(user,deleteimageurl);
@@ -193,7 +194,8 @@ public class SpotService {
                 comment.getComment(),
                 comment.getUser().getNickname(),
                 deletable,
-                comment.getCreatedDate()
+                comment.getCreatedDate(),
+                comment.getUser().getProfileimage()
         );
     }
 

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -111,6 +111,9 @@ public class UserService {
         //redis에서 해당 키 검색해서 해당 토큰에 대응하는 key 추출
         String userId = redisService.getValues(pureRefreshToken);
 
+        if (!redisService.checkExistsValue(userId)) {
+            throw new IncorrectRefreshTokenException();
+        }
         User user = userRepository.findByUserId(userId)
                 .orElseThrow(UserNotFoundException::new);
 


### PR DESCRIPTION
## 요약
이전 스프린트 회의에서 클라이언트에서 요청주신 사항들을 모두 해결하였습니다 ! 
추가적으로 refreshToken의 값이 Redis에 존재하지 않을시 반환되는 값도 수정하였습니다. ! 
구체적인 예외 처리 값은  
```java
    INCORRECT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "올바르지 않은 리프레시 토큰입니다. 기한이 만료되었거나, 이미 로그아웃이 완료되어 DB에 존재하지 않는 상태입니다."),

```
입니다 !! 
## 해결 목록 

- 페이지네이션 양식 통일 → 페이지네이션 동훈(좋아요/북마크) 방식 적용 ✅
- 장소 수정시, 이미지 인덱스 값 입력 받아서 삭제 / multipart 파일 입력은 수정 하는것으로 분리 ✅ 
- 댓글 등록시 프로필이미지 반환값 추가 → 혜리님 작업 완료 ✅