### PR TITLE
✔️ [Fix] : 사진 삭제 방식 변경 

### DIFF
--- a/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentListResponseDto.java
+++ b/src/main/java/com/cona/KUsukKusuk/comment/dto/CommentListResponseDto.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 public record CommentListResponseDto(
         String spotName,
         Long spotId,
+        Long commentId,
+
         String usersComment,
         String review,
         LocalDateTime CommentcreateDate,
@@ -29,6 +31,7 @@ public record CommentListResponseDto(
         return CommentListResponseDto.builder()
                 .spotName(comment.getSpot().getSpotName())
                 .spotImageurl(comment.getSpot().getImageUrls().get(0))
+                .commentId(comment.getId())
                 .CommentcreateDate(comment.getCreatedDate())
                 .spotId(comment.getId())
                 .review(comment.getSpot().getReview())

--- a/src/main/java/com/cona/KUsukKusuk/global/exception/HttpExceptionCode.java
+++ b/src/main/java/com/cona/KUsukKusuk/global/exception/HttpExceptionCode.java
@@ -39,7 +39,7 @@ public enum HttpExceptionCode {
     IMAGE_UPLOAD_FAILED(HttpStatus.NOT_FOUND, "이미지 업로드에 실패하였습니다."),
     SPOT_NOT_FOUND(HttpStatus.NOT_FOUND,"해당 spot ID가 DB에 존재하지 않습니다."),
     USER_LOGIN_PERMIT_FAIL(HttpStatus.FORBIDDEN,"로그인한 사용자만 이용할 수 있습니다. "),
-    USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "해당 사용자가 작성한 글이 아닙니다."),
+    USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "해당 사용자가 작성한 장소가 아닙니다."),
     BOOK_MARK_ERR(HttpStatus.BAD_REQUEST, "북마크 조회에 실패하였습니다."),
     BOOK_MARK_NOT_EXIST(HttpStatus.NOT_FOUND, "등록된 북마크가 존재하지 않습니다."),
     LIKE_ERR(HttpStatus.BAD_REQUEST, "좋아요 조회에 실피하였습니다."),

--- a/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotUpdateRequest.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/dto/SpotUpdateRequest.java
@@ -17,7 +17,7 @@ public record SpotUpdateRequest (
 
      String review,
 
-     int deleteImageindex
+     String[] deleteImageUrls
 ){
 
 }

--- a/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
+++ b/src/main/java/com/cona/KUsukKusuk/spot/service/SpotService.java
@@ -130,17 +130,18 @@ public class SpotService {
         if (!spot.getUser().equals(user)) {
             throw new UserNotFoundException(HttpExceptionCode.USER_NOT_MATCH);
         }
-        int deleteImageindex = spotUpdateRequest.deleteImageindex();
-
+        String[] deleteImageUrls = spotUpdateRequest.deleteImageUrls();
 
         List<String> imageUrls = spot.getImageUrls();
 
-        if (deleteImageindex>=1 && deleteImageindex<=imageUrls.size()) {
-            String deleteimageurl = imageUrls.get(deleteImageindex-1);
-            imageUrls.remove(deleteImageindex-1);
-            //해당 인덱스에 대응하는 이미지 삭제후 다시 저장(영속).
-            spot.setImageUrls(imageUrls);
-            s3Service.deleteImagebyUrl(user,deleteimageurl);
+        for (String deleteImageUrl : deleteImageUrls) {
+            if (imageUrls.contains(deleteImageUrl)) {
+                imageUrls.remove(deleteImageUrl);
+
+                spot.setImageUrls(imageUrls);
+                // S3에서 이미지 삭제
+                s3Service.deleteImagebyUrl(user, deleteImageUrl);
+            }
         }
 
         if (!images.get(0).isEmpty()) {

--- a/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
+++ b/src/main/java/com/cona/KUsukKusuk/user/service/UserService.java
@@ -147,6 +147,7 @@ public class UserService {
 
         String newPassword = generateNewPassword();
         member.setPassword(bCryptPasswordEncoder.encode(newPassword));
+
         member.setNoCryptpassword(newPassword);
         userRepository.save(member);
 
@@ -177,6 +178,7 @@ public class UserService {
         String storedPassword = userRepository.findByUserId(username)
                 .map(User::getPassword)
                 .orElseThrow(() -> new UserNotFoundException(HttpExceptionCode.USER_NOT_FOUND));
+
 
         if( ! bCryptPasswordEncoder.matches(enteredPassword, storedPassword)){
             throw new PasswordNotMatchException();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -47,11 +47,11 @@ spring:
 decorator:
   datasource:
     p6spy:
-      enable-logging: true
+      enable-logging: false
 
 logging:
   level:
-    org.hibernate.SQL: info
+    org.hibernate.SQL: error
 
 cloud:
   aws:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -11,7 +11,7 @@ spring:
         show_sql: true
         format_sql: true
     database: mysql
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: update
   jwt:


### PR DESCRIPTION
## 요약 
-  이번 스프린트에서 정현님께서 요청 주셨던 사항을 새로 구현하였습니다. 사진을 삭제할때 인덱스가 아니라 여러 사진을 삭제 할 수 있도록, S3  url 의 배열값으로 기존 장소에 등록된 사진을 삭제할 수 있도록 수정하였습니다.


## 상세

- 구체적으로 해당 배열을 순회하면서 해당 url이 기존 장소에 등록되어 있는 url인지 확인후 삭제한 다음, 다시 영속화 시키는 로직으로 구현하였습니다.